### PR TITLE
Add name to Docker Compose verification job

### DIFF
--- a/.github/workflows/compose-test.yml
+++ b/.github/workflows/compose-test.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
     compose-verify:
+        name: Verify Docker Compose Setup
         runs-on: ubuntu-latest
 
         steps:


### PR DESCRIPTION
Closes #45 

## What I have made

- Added name to 'Docker Compose verification job'

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does not apply.

- [ ] ~~I have commented my code (and updated the documentation accordingly)~~
- [ ] ~~I have added tests that prove my feature works or that my fix is effective~~
