### PR TITLE
chore(deps): bump js-yaml

### DIFF
--- a/apps/backend/package-lock.json
+++ b/apps/backend/package-lock.json
@@ -13,7 +13,7 @@
                 "@nestjs/config": "^4.0.2",
                 "@nestjs/core": "^11.0.1",
                 "@nestjs/platform-express": "^11.0.1",
-                "@nestjs/swagger": "^11.2.1",
+                "@nestjs/swagger": "^11.2.3",
                 "@nestjs/terminus": "^11.0.0",
                 "@nestjs/typeorm": "^11.0.0",
                 "@scalar/nestjs-api-reference": "^1.0.6",
@@ -2108,9 +2108,9 @@
             }
         },
         "node_modules/@microsoft/tsdoc": {
-            "version": "0.15.1",
-            "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.15.1.tgz",
-            "integrity": "sha512-4aErSrCR/On/e5G2hDP0wjooqDdauzEbIq8hIkIe5pXV0rtWJZvdCEKL0ykZxex+IxIwBp0eGeV48hQN07dXtw==",
+            "version": "0.16.0",
+            "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.16.0.tgz",
+            "integrity": "sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==",
             "license": "MIT"
         },
         "node_modules/@napi-rs/wasm-runtime": {
@@ -2588,17 +2588,17 @@
             }
         },
         "node_modules/@nestjs/swagger": {
-            "version": "11.2.1",
-            "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-11.2.1.tgz",
-            "integrity": "sha512-1MS7xf0pzc1mofG53xrrtrurnziafPUHkqzRm4YUVPA/egeiMaSerQBD/feiAeQ2BnX0WiLsTX4HQFO0icvOjQ==",
+            "version": "11.2.3",
+            "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-11.2.3.tgz",
+            "integrity": "sha512-a0xFfjeqk69uHIUpP8u0ryn4cKuHdra2Ug96L858i0N200Hxho+n3j+TlQXyOF4EstLSGjTfxI1Xb2E1lUxeNg==",
             "license": "MIT",
             "dependencies": {
-                "@microsoft/tsdoc": "0.15.1",
+                "@microsoft/tsdoc": "0.16.0",
                 "@nestjs/mapped-types": "2.1.0",
-                "js-yaml": "4.1.0",
+                "js-yaml": "4.1.1",
                 "lodash": "4.17.21",
                 "path-to-regexp": "8.3.0",
-                "swagger-ui-dist": "5.29.4"
+                "swagger-ui-dist": "5.30.2"
             },
             "peerDependencies": {
                 "@fastify/static": "^8.0.0",
@@ -7855,9 +7855,9 @@
             "license": "MIT"
         },
         "node_modules/js-yaml": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-            "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+            "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
             "license": "MIT",
             "dependencies": {
                 "argparse": "^2.0.1"
@@ -10397,9 +10397,9 @@
             }
         },
         "node_modules/swagger-ui-dist": {
-            "version": "5.29.4",
-            "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.29.4.tgz",
-            "integrity": "sha512-gJFDz/gyLOCQtWwAgqs6Rk78z9ONnqTnlW11gimG9nLap8drKa3AJBKpzIQMIjl5PD2Ix+Tn+mc/tfoT2tgsng==",
+            "version": "5.30.2",
+            "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.30.2.tgz",
+            "integrity": "sha512-HWCg1DTNE/Nmapt+0m2EPXFwNKNeKK4PwMjkwveN/zn1cV2Kxi9SURd+m0SpdcSgWEK/O64sf8bzXdtUhigtHA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@scarf/scarf": "=1.4.0"

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -24,7 +24,7 @@
         "@nestjs/config": "^4.0.2",
         "@nestjs/core": "^11.0.1",
         "@nestjs/platform-express": "^11.0.1",
-        "@nestjs/swagger": "^11.2.1",
+        "@nestjs/swagger": "^11.2.3",
         "@nestjs/terminus": "^11.0.0",
         "@nestjs/typeorm": "^11.0.0",
         "@scalar/nestjs-api-reference": "^1.0.6",


### PR DESCRIPTION
Bumps the npm_and_yarn group with 1 update in the /apps/backend directory: [js-yaml](https://github.com/nodeca/js-yaml).

Updates `js-yaml` from 4.1.0 to 4.1.1
- [Changelog](https://github.com/nodeca/js-yaml/blob/master/CHANGELOG.md)
- [Commits](https://github.com/nodeca/js-yaml/compare/4.1.0...4.1.1)

---
updated-dependencies:
- dependency-name: js-yaml dependency-version: 4.1.1 dependency-type: indirect dependency-group: npm_and_yarn ...