### PR TITLE
Return to nodenext

### DIFF
--- a/apps/backend/prisma/client/browser.ts
+++ b/apps/backend/prisma/client/browser.ts
@@ -13,10 +13,10 @@
  * 🟢 You can import this file directly.
  */
 
-import * as Prisma from './internal/prismaNamespaceBrowser'
+import * as Prisma from './internal/prismaNamespaceBrowser.js'
 export { Prisma }
-export * as $Enums from './enums'
-export * from './enums';
+export * as $Enums from './enums.js'
+export * from './enums.js';
 /**
  * Model User
  * 

--- a/apps/backend/prisma/client/client.ts
+++ b/apps/backend/prisma/client/client.ts
@@ -14,12 +14,12 @@ import * as process from 'node:process'
 import * as path from 'node:path'
 
 import * as runtime from "@prisma/client/runtime/client"
-import * as $Enums from "./enums"
-import * as $Class from "./internal/class"
-import * as Prisma from "./internal/prismaNamespace"
+import * as $Enums from "./enums.js"
+import * as $Class from "./internal/class.js"
+import * as Prisma from "./internal/prismaNamespace.js"
 
-export * as $Enums from './enums'
-export * from "./enums"
+export * as $Enums from './enums.js'
+export * from "./enums.js"
 /**
  * ## Prisma Client
  * 

--- a/apps/backend/prisma/client/commonInputTypes.ts
+++ b/apps/backend/prisma/client/commonInputTypes.ts
@@ -10,8 +10,8 @@
  */
 
 import type * as runtime from "@prisma/client/runtime/client"
-import * as $Enums from "./enums"
-import type * as Prisma from "./internal/prismaNamespace"
+import * as $Enums from "./enums.js"
+import type * as Prisma from "./internal/prismaNamespace.js"
 
 
 export type StringFilter<$PrismaModel = never> = {

--- a/apps/backend/prisma/client/internal/class.ts
+++ b/apps/backend/prisma/client/internal/class.ts
@@ -12,7 +12,7 @@
  */
 
 import * as runtime from "@prisma/client/runtime/client"
-import type * as Prisma from "./prismaNamespace"
+import type * as Prisma from "./prismaNamespace.js"
 
 
 const config: runtime.GetPrismaClientConfig = {

--- a/apps/backend/prisma/client/internal/prismaNamespace.ts
+++ b/apps/backend/prisma/client/internal/prismaNamespace.ts
@@ -16,10 +16,10 @@
  */
 
 import * as runtime from "@prisma/client/runtime/client"
-import type * as Prisma from "../models"
-import { type PrismaClient } from "./class"
+import type * as Prisma from "../models.js"
+import { type PrismaClient } from "./class.js"
 
-export type * from '../models'
+export type * from '../models.js'
 
 export type DMMF = typeof runtime.DMMF
 

--- a/apps/backend/prisma/client/internal/prismaNamespaceBrowser.ts
+++ b/apps/backend/prisma/client/internal/prismaNamespaceBrowser.ts
@@ -17,8 +17,8 @@
 
 import * as runtime from "@prisma/client/runtime/index-browser"
 
-export type * from '../models'
-export type * from './prismaNamespace'
+export type * from '../models.js'
+export type * from './prismaNamespace.js'
 
 export const Decimal = runtime.Decimal
 

--- a/apps/backend/prisma/client/models.ts
+++ b/apps/backend/prisma/client/models.ts
@@ -8,8 +8,8 @@
  *
  * 🟢 You can import this file directly.
  */
-export type * from './models/User'
-export type * from './models/Email'
-export type * from './models/Job'
-export type * from './models/JobResult'
-export type * from './commonInputTypes'
+export type * from './models/User.js'
+export type * from './models/Email.js'
+export type * from './models/Job.js'
+export type * from './models/JobResult.js'
+export type * from './commonInputTypes.js'

--- a/apps/backend/prisma/client/models/Email.ts
+++ b/apps/backend/prisma/client/models/Email.ts
@@ -9,8 +9,8 @@
  * 🟢 You can import this file directly.
  */
 import type * as runtime from "@prisma/client/runtime/client"
-import type * as $Enums from "../enums"
-import type * as Prisma from "../internal/prismaNamespace"
+import type * as $Enums from "../enums.js"
+import type * as Prisma from "../internal/prismaNamespace.js"
 
 /**
  * Model Email

--- a/apps/backend/prisma/client/models/Job.ts
+++ b/apps/backend/prisma/client/models/Job.ts
@@ -9,8 +9,8 @@
  * 🟢 You can import this file directly.
  */
 import type * as runtime from "@prisma/client/runtime/client"
-import type * as $Enums from "../enums"
-import type * as Prisma from "../internal/prismaNamespace"
+import type * as $Enums from "../enums.js"
+import type * as Prisma from "../internal/prismaNamespace.js"
 
 /**
  * Model Job

--- a/apps/backend/prisma/client/models/JobResult.ts
+++ b/apps/backend/prisma/client/models/JobResult.ts
@@ -9,8 +9,8 @@
  * 🟢 You can import this file directly.
  */
 import type * as runtime from "@prisma/client/runtime/client"
-import type * as $Enums from "../enums"
-import type * as Prisma from "../internal/prismaNamespace"
+import type * as $Enums from "../enums.js"
+import type * as Prisma from "../internal/prismaNamespace.js"
 
 /**
  * Model JobResult

--- a/apps/backend/prisma/client/models/User.ts
+++ b/apps/backend/prisma/client/models/User.ts
@@ -9,8 +9,8 @@
  * 🟢 You can import this file directly.
  */
 import type * as runtime from "@prisma/client/runtime/client"
-import type * as $Enums from "../enums"
-import type * as Prisma from "../internal/prismaNamespace"
+import type * as $Enums from "../enums.js"
+import type * as Prisma from "../internal/prismaNamespace.js"
 
 /**
  * Model User

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -1,6 +1,6 @@
 generator client {
-    provider = "prisma-client"
-    output   = "../prisma/client"
+    provider     = "prisma-client"
+    output       = "../prisma/client"
     moduleFormat = "cjs"
 }
 

--- a/apps/backend/tsconfig.json
+++ b/apps/backend/tsconfig.json
@@ -1,7 +1,8 @@
 {
     "compilerOptions": {
-        "module": "CommonJS",
-        "moduleResolution": "node",
+        "module": "NodeNext",
+        "moduleResolution": "NodeNext",
+        "resolvePackageJsonExports": true,
         "esModuleInterop": true,
         "isolatedModules": true,
         "declaration": true,
@@ -9,7 +10,7 @@
         "emitDecoratorMetadata": true,
         "experimentalDecorators": true,
         "allowSyntheticDefaultImports": true,
-        "target": "ES2017",
+        "target": "ES2023",
         "sourceMap": true,
         "outDir": "./dist",
         "baseUrl": "./",


### PR DESCRIPTION
Closes #58 

## What I have made

- Returned to `NodeNext` value for `module` property.

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does not apply.

- [ ] ~~I have commented my code (and updated the documentation accordingly)~~
- [ ] ~~I have added tests that prove my feature works or that my fix is effective~~
