### PR TITLE
fix(backend): add trusted_origins env to compose

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,3 +22,5 @@ BETTER_AUTH_URL=http://localhost:5175
 
 LANGFLOW_BASE_URL=https://sieve-flows.informatik.uni-ulm.de
 LANGFLOW_API_KEY=langflow-api-key-placeholder
+
+TRUSTED_ORIGINS=http://localhost:3000

--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -16,3 +16,5 @@ BETTER_AUTH_URL=http://localhost:5175
 
 LANGFLOW_BASE_URL=https://sieve-flows.informatik.uni-ulm.de
 LANGFLOW_API_KEY=langflow-api-key-placeholder
+
+TRUSTED_ORIGINS=http://localhost:3000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,8 @@ services:
 
             LANGFLOW_BASE_URL: ${LANGFLOW_BASE_URL}
             LANGFLOW_API_KEY: ${LANGFLOW_API_KEY}
+
+            TRUSTED_ORIGINS: ${TRUSTED_ORIGINS}
         ports:
             - ${BACKEND_PORT}:${BACKEND_PORT}
         depends_on:


### PR DESCRIPTION
Closes #102 

## What I have made

Add trusted origins to docker compose

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does not apply.

- [ ] I have commented my code (and updated the documentation accordingly)
- [ ] I have added tests that prove my feature works or that my fix is effective
