### PR TITLE
chore: move 'db-data' gitignore entry from backend to root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -189,3 +189,6 @@ $RECYCLE.BIN/
 
 docker-compose.override.yaml
 compose.override.yaml
+
+# DB
+db-data

--- a/apps/backend/.gitignore
+++ b/apps/backend/.gitignore
@@ -60,6 +60,3 @@ pids
 
 # Diagnostic reports (https://nodejs.org/api/report.html)
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
-
-# DB
-db-data


### PR DESCRIPTION
Closes <!-- issue reference -->

## What I have made
move 'db-data' gitignore entry from backend to root

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does not apply.

- [ ] I have commented my code (and updated the documentation accordingly)
- [ ] I have added tests that prove my feature works or that my fix is effective
