### PR TITLE
No longer create and publish docker images on PR

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,7 +6,8 @@ on:
             - Docker
         types:
             - completed
-        branches: [develop]
+        branches:
+            - develop
 
 concurrency:
     group: deploy

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,7 +6,6 @@ on:
             - develop
         tags:
             - "v*.*.*"
-    pull_request:
     workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Closes #150 

## What I have made

Currently, we always created and published new docker images when we push on a PR. This would also trigger the deploy workflow. In order for the deploy workflow to only trigger when there is a push on dev, we don't want to create a new docker image and publish is when we create a PR.

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does not apply.

- [x] I have commented my code (and updated the documentation accordingly)
- [x] I have added tests that prove my feature works or that my fix is effective
