### PR TITLE
Feat/254 feature add customer response generation to ai backend

### DIFF
--- a/apps/ai-backend/src/ai_backend/agent.py
+++ b/apps/ai-backend/src/ai_backend/agent.py
@@ -9,11 +9,10 @@ from ai_backend.utils import (
 )
 from ai_backend.product_flow import product_flow
 from langchain_core.callbacks import UsageMetadataCallbackHandler
-import asyncpg
+from asyncpg import Pool
 from langchain.messages import HumanMessage, SystemMessage, AIMessage
 from langgraph.types import Send
 from langchain.chat_models import init_chat_model
-from dotenv import load_dotenv
 from ai_backend.schemas import (
     Context,
     GraphState,
@@ -26,10 +25,10 @@ from ai_backend.schemas import (
 from langgraph.graph import StateGraph, START, END
 
 
-load_dotenv()
+async def get_database_schema(pool: Pool) -> dict[str, list[str]]:
+    if not pool:
+        return {}
 
-
-async def get_database_schema(pool: asyncpg.Pool) -> dict[str, list[str]]:
     async with pool.acquire() as conn:
         tables = await conn.fetch(
             """
@@ -194,7 +193,9 @@ workflow = (
     .add_node(categorize)
     .add_node("simple", simple_flow)
     .add_node("product", product_flow)
-    .add_node(overall_email_response, defer=True)
+    .add_node(
+        overall_email_response, defer=True
+    )  # defer because this should only run after all simple and product nodes are executed
     .add_edge(START, "categorize")
     .add_conditional_edges("categorize", route_to_flows, ["simple", "product"])
     .add_edge("simple", "overall_email_response")
@@ -206,7 +207,7 @@ workflow = (
 
 async def run_analyze_email_agent(
     analyseRequest: AnalyzeEmailRequest,
-    db_pool: asyncpg.Pool,
+    db_pool: Pool,
 ) -> GraphOutput:
     cb = UsageMetadataCallbackHandler()
 

--- a/apps/ai-backend/src/ai_backend/agent.py
+++ b/apps/ai-backend/src/ai_backend/agent.py
@@ -10,7 +10,7 @@ from ai_backend.utils import (
 from ai_backend.product_flow import product_flow
 from langchain_core.callbacks import UsageMetadataCallbackHandler
 import asyncpg
-from langchain.messages import HumanMessage, SystemMessage
+from langchain.messages import HumanMessage, SystemMessage, AIMessage
 from langgraph.types import Send
 from langchain.chat_models import init_chat_model
 from dotenv import load_dotenv
@@ -21,7 +21,7 @@ from ai_backend.schemas import (
     AnalyzeEmailRequest,
     ModelConfig,
     GraphOutput,
-    FlowResult,
+    EmailResponseSchema,
 )
 from langgraph.graph import StateGraph, START, END
 
@@ -103,6 +103,7 @@ async def categorize(state: GraphState, runtime: Runtime[Context]) -> dict:
 
     result = await structured.ainvoke(
         [
+            HumanMessage(format_email(context.email)),
             SystemMessage(
                 """Your job is to categorize an email from a customer into the possible categories. 
                 If the customer has multiple requests that fit different categories, list multiple different categories. 
@@ -117,7 +118,6 @@ async def categorize(state: GraphState, runtime: Runtime[Context]) -> dict:
                     ]
                 )
             ),
-            HumanMessage(format_email(context.email)),
         ]
     )
 
@@ -129,13 +129,52 @@ async def categorize(state: GraphState, runtime: Runtime[Context]) -> dict:
     return {"categories": result["categories"]}
 
 
+async def overall_email_response(state: GraphState, runtime: Runtime[Context]) -> dict:
+    parts = [
+        flow.steps.email_response
+        for flow in state.category_results
+        if flow.steps.email_response
+    ]
+
+    if len(parts) == 0:
+        return {"email_response": None}
+
+    formatted_parts = {"\n\n".join([part.response_body_part for part in parts])}
+
+    structured = runtime.context.simple_model.with_structured_output(
+        EmailResponseSchema
+    )
+
+    conversation = [
+        HumanMessage(format_email(runtime.context.email)),
+        SystemMessage(
+            """Your job is create a comprehensive email to the customer using the parts provided below. 
+            Reformulate parts if necessary. 
+            Include email saluation and closing greeting. 
+            Do not include the subject in the email body."""
+        ),
+        AIMessage(f"Drafted email parts: {formatted_parts}"),
+    ]
+
+    custom_prompt = runtime.context.global_config.overall_email_response_prompt
+
+    if custom_prompt:
+        conversation.append(SystemMessage(custom_prompt))
+
+    result = await structured.ainvoke(conversation)
+    assert isinstance(
+        result, EmailResponseSchema
+    )  # Tell ty that this an EmailResponseSchema
+
+    return {"email_response": result.result}
+
+
 def init_simple_model(model_config: ModelConfig):
     return init_chat_model(
         model_provider=get_provider_name(model_config.provider),
         model=model_config.simple_model,
         temperature=0.1,
         timeout=10,
-        max_tokens=10000,
         api_key=model_config.api_key,
     )
 
@@ -146,20 +185,21 @@ def init_complex_model(model_config: ModelConfig):
         model=model_config.complex_model,
         temperature=0.1,
         timeout=10,
-        max_tokens=10000,
         api_key=model_config.api_key,
     )
 
 
 workflow = (
     StateGraph(GraphState, output_schema=GraphOutput, context_schema=Context)
-    .add_node("categorize", categorize)
+    .add_node(categorize)
     .add_node("simple", simple_flow)
     .add_node("product", product_flow)
+    .add_node(overall_email_response, defer=True)
     .add_edge(START, "categorize")
     .add_conditional_edges("categorize", route_to_flows, ["simple", "product"])
-    .add_edge("simple", END)
-    .add_edge("product", END)
+    .add_edge("simple", "overall_email_response")
+    .add_edge("product", "overall_email_response")
+    .add_edge("overall_email_response", END)
     .compile()
 )
 
@@ -167,7 +207,7 @@ workflow = (
 async def run_analyze_email_agent(
     analyseRequest: AnalyzeEmailRequest,
     db_pool: asyncpg.Pool,
-) -> list[FlowResult]:
+) -> GraphOutput:
     cb = UsageMetadataCallbackHandler()
 
     simple_model = init_simple_model(analyseRequest.model)
@@ -183,11 +223,12 @@ async def run_analyze_email_agent(
         complex_model=complex_model,
         email=analyseRequest.email,
         categories=analyseRequest.categories,
+        global_config=analyseRequest.config,
     )
     config = RunnableConfig(callbacks=[cb])
 
     # Result is not a pydantic object but a normal python dict
-    result = await workflow.ainvoke(
+    raw_result = await workflow.ainvoke(
         GraphState(),
         config=config,
         context=context,
@@ -197,4 +238,6 @@ async def run_analyze_email_agent(
 
     print(f"💸 Usage metadata: {cb.usage_metadata}")
 
-    return result["results"]
+    result = GraphOutput(**raw_result)
+
+    return result

--- a/apps/ai-backend/src/ai_backend/agent.py
+++ b/apps/ai-backend/src/ai_backend/agent.py
@@ -186,6 +186,7 @@ async def run_analyze_email_agent(
     )
     config = RunnableConfig(callbacks=[cb])
 
+    # Result is not a pydantic object but a normal python dict
     result = await workflow.ainvoke(
         GraphState(),
         config=config,

--- a/apps/ai-backend/src/ai_backend/agent.py
+++ b/apps/ai-backend/src/ai_backend/agent.py
@@ -138,7 +138,7 @@ async def overall_email_response(state: GraphState, runtime: Runtime[Context]) -
     if len(parts) == 0:
         return {"email_response": None}
 
-    formatted_parts = {"\n\n".join([part.response_body_part for part in parts])}
+    formatted_parts = "\n\n".join(part.response_body_part for part in parts)
 
     structured = runtime.context.simple_model.with_structured_output(
         EmailResponseSchema
@@ -149,7 +149,7 @@ async def overall_email_response(state: GraphState, runtime: Runtime[Context]) -
         SystemMessage(
             """Your job is create a comprehensive email to the customer using the parts provided below. 
             Reformulate parts if necessary. 
-            Include email saluation and closing greeting. 
+            Include email salutation and closing greeting. 
             Do not include the subject in the email body."""
         ),
         AIMessage(f"Drafted email parts: {formatted_parts}"),

--- a/apps/ai-backend/src/ai_backend/main.py
+++ b/apps/ai-backend/src/ai_backend/main.py
@@ -1,6 +1,6 @@
 from pydantic import BaseModel
 from typing import Literal
-from ai_backend.schemas import AnalyzeEmailRequest, FlowResult
+from ai_backend.schemas import AnalyzeEmailRequest, GraphOutput
 import os
 import asyncpg
 from ai_backend.agent import run_analyze_email_agent
@@ -8,7 +8,7 @@ from fastapi import FastAPI
 
 
 def create_pool():
-    pool = asyncpg.create_pool(
+    pool = asyncpg.create_pool(  # TODO when no configured, skip
         user=os.environ.get("PRODUCT_DB_USERNAME"),
         password=os.environ.get("PRODUCT_DB_PASSWORD"),
         database=os.environ.get("PRODUCT_DB_NAME"),
@@ -27,7 +27,7 @@ app = FastAPI()
 
 class AnalyzeResult(BaseModel):
     status: Literal["success"]
-    data: list[FlowResult]
+    data: GraphOutput
 
 
 @app.post("/analyze-email")

--- a/apps/ai-backend/src/ai_backend/main.py
+++ b/apps/ai-backend/src/ai_backend/main.py
@@ -1,3 +1,4 @@
+from dotenv import load_dotenv
 from pydantic import BaseModel
 from typing import Literal
 from ai_backend.schemas import AnalyzeEmailRequest, GraphOutput
@@ -6,16 +7,22 @@ import asyncpg
 from ai_backend.agent import run_analyze_email_agent
 from fastapi import FastAPI
 
+load_dotenv()
 
-def create_pool():
-    pool = asyncpg.create_pool(  # TODO when no configured, skip
+
+async def create_pool():
+    if not os.environ.get("PRODUCT_DB_NAME"):
+        print("No prodct database configured. Product Flow will not work")
+        return None
+
+    pool = await asyncpg.create_pool(
         user=os.environ.get("PRODUCT_DB_USERNAME"),
         password=os.environ.get("PRODUCT_DB_PASSWORD"),
         database=os.environ.get("PRODUCT_DB_NAME"),
         host=os.environ.get("PRODUCT_DB_HOST"),
         port=os.environ.get("PRODUCT_DB_PORT"),
-        min_size=1,
-        max_size=10,
+        min_size=0,
+        max_size=5,
     )
     print("Database pool created")
 
@@ -33,9 +40,13 @@ class AnalyzeResult(BaseModel):
 @app.post("/analyze-email")
 async def analyze_email(request: AnalyzeEmailRequest) -> AnalyzeResult:
     # Use a separate pool for each request to allow dynamic credentials from backend in the future
-    async with create_pool() as pool:
+    pool = await create_pool()
+    try:
         result = await run_analyze_email_agent(
             analyseRequest=request,
             db_pool=pool,
         )
         return AnalyzeResult(status="success", data=result)
+    finally:
+        if pool:
+            await pool.close()

--- a/apps/ai-backend/src/ai_backend/main.py
+++ b/apps/ai-backend/src/ai_backend/main.py
@@ -12,7 +12,7 @@ load_dotenv()
 
 async def create_pool():
     if not os.environ.get("PRODUCT_DB_NAME"):
-        print("No prodct database configured. Product Flow will not work")
+        print("No product database configured. Product Flow will not work")
         return None
 
     pool = await asyncpg.create_pool(

--- a/apps/ai-backend/src/ai_backend/product_flow.py
+++ b/apps/ai-backend/src/ai_backend/product_flow.py
@@ -1,5 +1,5 @@
 from typing import Annotated
-from ai_backend.shared_flow import summary, structured_response
+from ai_backend.shared_flow import summary, structured_response, email_response
 from ai_backend.utils import format_email
 from langchain.messages import SystemMessage, HumanMessage
 from langchain.agents import create_agent, AgentState
@@ -36,7 +36,7 @@ async def search_product(
         raise ToolException("Max tries (10) for this tool reached.")
 
     if tool_calls >= 5:
-        return "search_product Tool call limit exceeded. Now return the result with the potentialProducts and your confidence score."
+        return "search_product Tool call limit exceeded. Now return the result with the related_products and your confidence score."
 
     db_schema = runtime.context.db_schema
     if table_name not in db_schema:
@@ -81,6 +81,7 @@ async def db_step(
         context_schema=Context,
     )
     conversation = [
+        HumanMessage(format_email(runtime.context.email)),
         SystemMessage(f"""Your job is to find the product(s) the customer wants to buy or is talking about in their email. 
         Only use the parts of the email that relates to the category '{category.name}: {category.description}' and ignore other parts.
         Use the search_product tool to find the products the customer might want, use the provided database schema (tables and their columns). 
@@ -92,8 +93,6 @@ async def db_step(
     if category.flow.db_step_prompt:
         conversation.append(SystemMessage(category.flow.db_step_prompt))
 
-    conversation.append(HumanMessage(format_email(runtime.context.email)))
-
     result = await agent.ainvoke(
         {"messages": conversation},
         context=runtime.context,
@@ -104,7 +103,7 @@ async def db_step(
     for msg in result["messages"]:
         msg.pretty_print()
 
-    return {"steps": {"db_step": result["structured_response"].potentialProducts}}
+    return {"steps": {"db_step": result["structured_response"]}}
 
 
 product_subgraph = (
@@ -113,13 +112,15 @@ product_subgraph = (
         output_schema=FlowResult[ProductFlowSteps],
         context_schema=Context,
     )
-    .add_node("db_step", db_step, retry_policy=RetryPolicy(max_attempts=3))
-    .add_node("structured_response", structured_response)
-    .add_node("summary", summary)
+    .add_node(db_step, retry_policy=RetryPolicy(max_attempts=3))
+    .add_node(structured_response)
+    .add_node(summary)
+    .add_node(email_response)
     .add_edge(START, "db_step")
     .add_edge(START, "summary")
     .add_edge("db_step", "structured_response")
-    .add_edge(["structured_response", "summary"], END)
+    .add_edge("structured_response", "email_response")
+    .add_edge(["structured_response", "summary", "email_response"], END)
     .compile()
 )
 
@@ -127,7 +128,7 @@ product_subgraph = (
 async def product_flow(state: FlowGraphState, runtime: Runtime[Context]) -> dict:
     """Flow that additionally tries to find products in the database. Plus summary and structured response"""
 
-    print(f"▶️ START product flow Category {state.category_config}")
+    print(f"▶️ START product flow Category {state.category_config.name}")
 
     raw_response = await product_subgraph.ainvoke(state, context=runtime.context)
 
@@ -136,4 +137,4 @@ async def product_flow(state: FlowGraphState, runtime: Runtime[Context]) -> dict
 
     print(f"✔️ END Category {state.category}")
 
-    return {"results": [response]}
+    return {"category_results": [response]}

--- a/apps/ai-backend/src/ai_backend/product_flow.py
+++ b/apps/ai-backend/src/ai_backend/product_flow.py
@@ -128,7 +128,7 @@ product_subgraph = (
 async def product_flow(state: FlowGraphState, runtime: Runtime[Context]) -> dict:
     """Flow that additionally tries to find products in the database. Plus summary and structured response"""
 
-    print(f"▶️ START product flow Category {state.category_config.name}")
+    print(f"▶️ START product flow Category {state.category_config}")
 
     raw_response = await product_subgraph.ainvoke(state, context=runtime.context)
 

--- a/apps/ai-backend/src/ai_backend/product_flow.py
+++ b/apps/ai-backend/src/ai_backend/product_flow.py
@@ -11,6 +11,7 @@ from ai_backend.schemas import (
     ProductFlowSteps,
     ProductFlowConfig,
 )
+from langgraph.types import RetryPolicy
 from langgraph.runtime import Runtime
 from langchain.tools import tool, ToolRuntime, InjectedState, ToolException
 from langgraph.graph import StateGraph, START, END
@@ -112,7 +113,7 @@ product_subgraph = (
         output_schema=FlowResult[ProductFlowSteps],
         context_schema=Context,
     )
-    .add_node("db_step", db_step)
+    .add_node("db_step", db_step, retry_policy=RetryPolicy(max_attempts=3))
     .add_node("structured_response", structured_response)
     .add_node("summary", summary)
     .add_edge(START, "db_step")
@@ -133,6 +134,6 @@ async def product_flow(state: FlowGraphState, runtime: Runtime[Context]) -> dict
     # Check if really valid and make ty happy
     response = FlowResult[ProductFlowSteps](**raw_response)
 
-    print(f"✔️ END Category {state.category_config} Result: ", response)
+    print(f"✔️ END Category {state.category}")
 
     return {"results": [response]}

--- a/apps/ai-backend/src/ai_backend/schemas.py
+++ b/apps/ai-backend/src/ai_backend/schemas.py
@@ -29,6 +29,7 @@ class SimpleFlowConfig(BaseModel):
     structured_response_schema: dict[str, Any]
     structured_response_prompt: str | None = Field(None, max_length=1000)
     summary_prompt: str | None = Field(None, max_length=1000)
+    email_response_prompt: str | None = Field(None, max_length=1000)
 
 
 class ProductFlowConfig(BaseModel):
@@ -37,6 +38,7 @@ class ProductFlowConfig(BaseModel):
     structured_response_prompt: str | None = Field(None, max_length=1000)
     summary_prompt: str | None = Field(None, max_length=1000)
     db_step_prompt: str | None = Field(None, max_length=1000)
+    email_response_prompt: str | None = Field(None, max_length=1000)
 
 
 FlowConfig = Union[SimpleFlowConfig, ProductFlowConfig]
@@ -53,10 +55,15 @@ class CategoryConfig(BaseModel, Generic[FlowConfigType]):
 Categories = list[CategoryConfig]
 
 
+class GlobalConfig(BaseModel):
+    overall_email_response_prompt: str | None = Field(None, max_length=1000)
+
+
 class AnalyzeEmailRequest(BaseModel):
     email: Email
     model: ModelConfig
     categories: Categories
+    config: GlobalConfig
 
 
 ## LangGraph Schemas ##
@@ -79,22 +86,34 @@ class Product(BaseModel):
 
 
 class SearchResult(BaseModel):
-    potentialProducts: list[Product] = Field(
+    related_products: list[Product] = Field(
         description="Products from the search you think are the ones the customer was talking about"
     )
     confidence: float = Field(
-        description="How confident you are that the products are the ones the customer meant"
+        description="How confident you are that the products you found are the ones the customer meant"
     )
+
+
+class EmailResponsePart(BaseModel):
+    response_body_part: str = Field(
+        description="Part of the drafted email response to the customer"
+    )
+
+
+class EmailResponsePartSchema(BaseModel):
+    result: EmailResponsePart | None
 
 
 ## Flow Graph:
 class SimpleFlowSteps(BaseModel):
     summary: str
+    email_response: EmailResponsePart | None = Field(default=None)
 
 
 class ProductFlowSteps(BaseModel):
     summary: str
-    db_step: list[Product]
+    db_step: SearchResult
+    email_response: EmailResponsePart | None = Field(default=None)
 
 
 FlowSteps = Union[SimpleFlowSteps, ProductFlowSteps]
@@ -123,10 +142,23 @@ class Context:
     complex_model: BaseChatModel
     email: Email
     categories: Categories
+    global_config: GlobalConfig
+
+
+class EmailResponse(BaseModel):
+    response_body: str = Field(description="Email body of the response to the customer")
+    response_subject: str = Field(
+        description="Email subject of the response to the customer"
+    )
+
+
+class EmailResponseSchema(BaseModel):
+    result: EmailResponse | None
 
 
 class GraphOutput(BaseModel):
-    results: Annotated[list[FlowResult], operator.add] = []
+    category_results: Annotated[list[FlowResult], operator.add] = []
+    email_response: EmailResponse | None = Field(default=None)
 
 
 class GraphState(GraphOutput):

--- a/apps/ai-backend/src/ai_backend/schemas.py
+++ b/apps/ai-backend/src/ai_backend/schemas.py
@@ -1,6 +1,6 @@
 from langchain.chat_models import BaseChatModel
 import operator
-import asyncpg
+from asyncpg import Pool
 from dataclasses import dataclass
 from typing import Literal, Union, Any, Annotated, TypeVar, Generic
 
@@ -136,7 +136,7 @@ class FlowGraphState(BaseModel, Generic[FlowConfigType]):
 ## Top Level Graph:
 @dataclass
 class Context:
-    db_pool: asyncpg.Pool
+    db_pool: Pool
     db_schema: dict[str, list[str]]
     simple_model: BaseChatModel
     complex_model: BaseChatModel

--- a/apps/ai-backend/src/ai_backend/shared_flow.py
+++ b/apps/ai-backend/src/ai_backend/shared_flow.py
@@ -1,12 +1,12 @@
-from pydantic import TypeAdapter
-from ai_backend.utils import format_email
+from ai_backend.utils import format_email, dict_to_json
 from langchain.messages import SystemMessage, HumanMessage
 from langgraph.runtime import Runtime
-from ai_backend.schemas import FlowGraphState, Context
+from ai_backend.schemas import FlowGraphState, Context, EmailResponsePartSchema
 
 
 async def summary(state: FlowGraphState, runtime: Runtime[Context]) -> dict:
     messages = [
+        HumanMessage(format_email(runtime.context.email)),
         SystemMessage(
             f"""Your job is to summarize the part of the customer's email that relates to the category '{state.category_config.name}: {state.category_config.description}' and ignore other parts."""
         ),
@@ -15,8 +15,6 @@ async def summary(state: FlowGraphState, runtime: Runtime[Context]) -> dict:
     summary_prompt = state.category_config.flow.summary_prompt
     if summary_prompt:
         messages.append(SystemMessage(summary_prompt))
-
-    messages.append(HumanMessage(format_email(runtime.context.email)))
 
     result = await runtime.context.simple_model.ainvoke(messages)
 
@@ -36,12 +34,10 @@ async def structured_response(state: FlowGraphState, runtime: Runtime[Context]) 
 
     structured = runtime.context.simple_model.with_structured_output(schema)
 
-    # Convert steps to json, this can contain pydantic objects or python dicts
-    adapter = TypeAdapter(dict)
-    json_bytes = adapter.dump_json(state.steps)
-    json_string = json_bytes.decode()
+    json_string = dict_to_json(state.steps)
 
     messages = [
+        HumanMessage(format_email(runtime.context.email)),
         SystemMessage(
             f"""Your job is to convert a customer's email into a structured form. Only use the parts of the email that relates to the category '{state.category_config.name}: {state.category_config.description}' and ignore other parts."""
         ),
@@ -53,7 +49,31 @@ async def structured_response(state: FlowGraphState, runtime: Runtime[Context]) 
             SystemMessage(state.category_config.flow.structured_response_prompt)
         )
 
-    messages.append(HumanMessage(format_email(runtime.context.email)))
-
     result = await structured.ainvoke(messages)
     return {"structured_output": result}
+
+
+async def email_response(state: FlowGraphState, runtime: Runtime[Context]) -> dict:
+    category = state.category_config
+
+    structured = runtime.context.complex_model.with_structured_output(
+        EmailResponsePartSchema
+    )
+
+    conversation = [
+        HumanMessage(format_email(runtime.context.email)),
+        SystemMessage(f"""Your job is to draft an email response to the customer. This can only contain things that you are explicitly told to include.
+        Only respond to the parts of the email that relates to the category '{category.name}: {category.description}' and ignore other parts.
+        Do not draft a complete email, only a section."""),
+        SystemMessage(f"Related information: : {dict_to_json(state.steps)}"),
+    ]
+
+    if category.flow.email_response_prompt:
+        conversation.append(SystemMessage(category.flow.email_response_prompt))
+
+    result = await structured.ainvoke(conversation)
+    assert isinstance(
+        result, EmailResponsePartSchema
+    )  # Tell ty that this an EmailResponseSchema
+
+    return {"steps": {"email_response": result.result}}

--- a/apps/ai-backend/src/ai_backend/simple_flow.py
+++ b/apps/ai-backend/src/ai_backend/simple_flow.py
@@ -1,4 +1,4 @@
-from ai_backend.shared_flow import summary, structured_response
+from ai_backend.shared_flow import summary, structured_response, email_response
 from langgraph.runtime import Runtime
 from ai_backend.schemas import (
     FlowGraphState,
@@ -16,11 +16,13 @@ simple_subgraph = (
         output_schema=FlowResult[SimpleFlowSteps],
         context_schema=Context,
     )
-    .add_node("structured_response", structured_response)
-    .add_node("summary", summary)
+    .add_node(structured_response)
+    .add_node(summary)
+    .add_node(email_response)
     .add_edge(START, "summary")
     .add_edge(START, "structured_response")
-    .add_edge(["summary", "structured_response"], END)
+    .add_edge(START, "email_response")
+    .add_edge(["summary", "structured_response", "email_response"], END)
     .compile()
 )
 
@@ -37,4 +39,4 @@ async def simple_flow(state: FlowGraphState, runtime: Runtime[Context]) -> dict:
 
     print(f"✔️ END Category {state.category}")
 
-    return {"results": [response]}
+    return {"category_results": [response]}

--- a/apps/ai-backend/src/ai_backend/simple_flow.py
+++ b/apps/ai-backend/src/ai_backend/simple_flow.py
@@ -35,6 +35,6 @@ async def simple_flow(state: FlowGraphState, runtime: Runtime[Context]) -> dict:
     # Check if really valid and make ty happy
     response = FlowResult[SimpleFlowSteps](**raw_response)
 
-    print(f"✔️ END Category {state.category_config.name} Result: ", response)
+    print(f"✔️ END Category {state.category}")
 
     return {"results": [response]}

--- a/apps/ai-backend/src/ai_backend/utils.py
+++ b/apps/ai-backend/src/ai_backend/utils.py
@@ -1,3 +1,4 @@
+from pydantic import TypeAdapter
 from ai_backend.schemas import (
     Email,
     Categories,
@@ -7,8 +8,8 @@ from ai_backend.schemas import (
 
 def format_email(email: Email) -> str:
     if email.subject is None:
-        return f"Email body:\n{email.body}"
-    return f"Email subject:\n{email.subject}\n\nEmail body:\n{email.body}"
+        return f"Customer email:\nBody:\n{email.body}"
+    return f"Customer email:\nSubject: {email.subject}\nBody:\n{email.body}"
 
 
 def get_categories(categories: Categories) -> list[str]:
@@ -32,3 +33,10 @@ def get_provider_name(provider: str) -> str:
         return "google_vertexai"
     else:
         raise ValueError(f"Unknown provider: {provider}")
+
+
+def dict_to_json(data: dict) -> str:
+    """Convert a dict to json, this can contain pydantic objects or python dicts"""
+    adapter = TypeAdapter(dict)
+    json_bytes = adapter.dump_json(data)
+    return json_bytes.decode()

--- a/apps/backend/src/ai-backend/ai-backend.service.ts
+++ b/apps/backend/src/ai-backend/ai-backend.service.ts
@@ -201,10 +201,10 @@ export class AiBackendService implements OnModuleInit {
                                 },
                                 db_step_prompt:
                                     "Database hints: The database only contains lego sets. The metadata column contains the part count. The products in the database are named in german",
-                                email_response_prompt: `If no matching product is found, please tell the customer that you could not find it and ask which product exactly they were referring too. 
+                                email_response_prompt: `If no matching product is found, please tell the customer that you could not find it and ask which product exactly they were referring to. 
 If there are multiple ask to clarify which one the customers want.
 If the customer has questions that can be answered based on the related information, answer it.
-If the customer has no questions and wants to immediatly place the order: The following information is needed: Name, Address. If those are not provided, ask the customer. Else tell the customer that the order is placed.
+If the customer has no questions and wants to immediately place the order: The following information is needed: Name, Address. If those are not provided, ask the customer. Else tell the customer that the order is placed.
 If nothing of the above matches, do not respond.`,
                             },
                         },

--- a/apps/backend/src/ai-backend/ai-backend.service.ts
+++ b/apps/backend/src/ai-backend/ai-backend.service.ts
@@ -78,6 +78,10 @@ export class AiBackendService implements OnModuleInit {
                         simple_model: "gpt-4o-mini",
                         complex_model: "gpt-5.2",
                     },
+                    config: {
+                        overall_email_response_prompt:
+                            "Verwende Emojis, antworte in der Du-Form. Name für Gruß unten: Simon Eve, Sieve Enterprises Corp. Ganz am Ende soll noch ein zufälliger, sinnloser Werbespruch stehen.",
+                    },
                     categories: [
                         {
                             name: "Complaint",
@@ -104,9 +108,11 @@ export class AiBackendService implements OnModuleInit {
                                     type: "object",
                                 },
                                 structured_response_prompt:
-                                    "Be extremely concise. List every complaint twice. Once in English, once in French",
+                                    "Be extremely concise.",
                                 summary_prompt:
                                     "Include every little detail of the complaint. Answer in French.",
+                                email_response_prompt:
+                                    "In the response tell the customner that its their fault and be rude.",
                             },
                         },
                         {
@@ -182,27 +188,9 @@ export class AiBackendService implements OnModuleInit {
                                             title: "Products",
                                             type: "array",
                                         },
-                                        question: {
-                                            anyOf: [
-                                                { type: "string" },
-                                                { type: "null" },
-                                            ],
-                                            default: null,
-                                            title: "Question",
-                                        },
-                                        answer: {
-                                            anyOf: [
-                                                { type: "string" },
-                                                { type: "null" },
-                                            ],
-                                            default: null,
-                                            description:
-                                                "If the customer asked a question and you can answer the question based on the provided product details, then answer here",
-                                            title: "Answer",
-                                        },
                                         urgency: {
                                             description:
-                                                "How urgent is the complaint from 0 (not urgent) to 100 (very urgent)",
+                                                "How urgent is the inquiry from 0 (not urgent) to 100 (very urgent)",
                                             title: "Urgency",
                                             type: "integer",
                                         },
@@ -213,6 +201,11 @@ export class AiBackendService implements OnModuleInit {
                                 },
                                 db_step_prompt:
                                     "Database hints: The database only contains lego sets. The metadata column contains the part count. The products in the database are named in german",
+                                email_response_prompt: `If no matching product is found, please tell the customer that you could not find it and ask which product exactly they were referring too. 
+If there are multiple ask to clarify which one the customers want.
+If the customer has questions that can be answered based on the related information, answer it.
+If the customer has no questions and wants to immediatly place the order: The following information is needed: Name, Address. If those are not provided, ask the customer. Else tell the customer that the order is placed.
+If nothing of the above matches, do not respond.`,
                             },
                         },
                         {
@@ -325,6 +318,8 @@ export class AiBackendService implements OnModuleInit {
                                     "Database hints: The database only contains lego sets. The metadata column contains the part count. The products in the database are named in german",
                                 summary_prompt:
                                     "Answer in German. In sehr kurzen Stichworten antworten",
+                                email_response_prompt:
+                                    "If the complaint is reasonable, answer that you are sorry and that we will fix it as soon as possible.",
                             },
                         },
                         {
@@ -345,6 +340,7 @@ export class AiBackendService implements OnModuleInit {
                                 },
                                 summary_prompt:
                                     "Be extremely concise. Answer in English",
+                                email_response_prompt: "Do not respond.",
                             },
                         },
                     ],


### PR DESCRIPTION
Closes #254 

## What I have made
* an overall email response to the customer is generated if deemed necessary by the llm
* the flow of each category can generate email response parts
* in the end an overall response is generated out of the parts
* Allow analyse requests without configured product db
