### PR TITLE
fix(backend): treat empty smtp user and pass as unset

### DIFF
--- a/apps/backend/src/smtp/smtp.service.ts
+++ b/apps/backend/src/smtp/smtp.service.ts
@@ -35,10 +35,7 @@ export class SmtpService implements OnModuleInit {
             host,
             port,
             secure: port === 465,
-            auth:
-                user !== undefined && pass !== undefined
-                    ? { user, pass }
-                    : undefined, // Only authenticate if username and password are provided
+            auth: user && pass ? { user, pass } : undefined, // Only authenticate if username and password are provided
         });
 
         Logger.log("SMTP module initialized");


### PR DESCRIPTION
## What I have made
fix(backend): treat empty smtp user and pass as unset
Because they are always set in the compose and not setting them in the .env file leads to them being an empty string
