### PR TITLE
fix(frontend): In history view in workflow the container is sometimes…

### DIFF
--- a/apps/frontend/src/components/composites/views/history/history-view.tsx
+++ b/apps/frontend/src/components/composites/views/history/history-view.tsx
@@ -160,7 +160,7 @@ export function HistoryView({ history = [] }: HistoryViewProps) {
 
             <SplitViewPane variant="secondary" isScrollable>
                 {selectedItem ? (
-                    <div className="mx-auto flex min-h-full w-full max-w-4xl flex-col gap-4">
+                    <div className="mx-auto flex min-h-full w-full flex-col gap-4">
                         <section className="rounded-2xl border border-slate-200 bg-white p-5 dark:border-slate-800 dark:bg-slate-900/60">
                             <h3 className="text-sm font-semibold tracking-wide text-slate-500 uppercase dark:text-slate-400">
                                 Email


### PR DESCRIPTION
fix(frontend): In history view in workflow the container is sometimes to narrow

Remove max-w-4xl
<img width="1920" height="1510" alt="image" src="https://github.com/user-attachments/assets/d6d4f341-787f-4ebe-bfc2-f333a3ab42da" />
