### PR TITLE
feat(history): add handled status with filter and response button

### DIFF
--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -103,6 +103,7 @@ model Job {
     createdAt   DateTime   @default(now())
     updatedAt   DateTime   @updatedAt
     result      JobResult?
+    handled     Boolean    @default(false)
 
     @@map("jobs")
 }

--- a/apps/backend/src/email/dto/email-analysis-result.dto.ts
+++ b/apps/backend/src/email/dto/email-analysis-result.dto.ts
@@ -1,4 +1,5 @@
 import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
+import { IsUUID } from "class-validator";
 
 export class FlowSteps {
     @ApiProperty({
@@ -95,4 +96,11 @@ export class SubmitEmailResponseDto {
         type: "boolean",
     })
     email_response_sent: boolean = false;
+
+    @ApiProperty({
+        description: "The ID of the job created for this analysis.",
+        type: String,
+    })
+    @IsUUID()
+    jobId!: string;
 }

--- a/apps/backend/src/email/dto/send-email-response.dto.ts
+++ b/apps/backend/src/email/dto/send-email-response.dto.ts
@@ -1,5 +1,11 @@
-import { ApiProperty } from "@nestjs/swagger";
-import { IsEmail, IsNotEmpty, IsString } from "class-validator";
+import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
+import {
+    IsEmail,
+    IsNotEmpty,
+    IsOptional,
+    IsString,
+    IsUUID,
+} from "class-validator";
 
 export class SendEmailResponseDto {
     @ApiProperty({
@@ -31,4 +37,12 @@ export class SendEmailResponseDto {
     @IsString()
     @IsNotEmpty()
     body!: string;
+
+    @ApiPropertyOptional({
+        description: "Job ID to mark as handled after a successful send.",
+        type: String,
+    })
+    @IsOptional()
+    @IsUUID()
+    jobId?: string;
 }

--- a/apps/backend/src/email/email.controller.ts
+++ b/apps/backend/src/email/email.controller.ts
@@ -15,6 +15,7 @@ import {
     ApiTags,
 } from "@nestjs/swagger";
 import { Session, type UserSession } from "@thallesp/nestjs-better-auth";
+import { JobService } from "src/job/job.service";
 import { SmtpService } from "src/smtp/smtp.service";
 import { CreateEmailDto } from "./dto/create-email.dto";
 import { SubmitEmailResponseDto } from "./dto/email-analysis-result.dto";
@@ -30,6 +31,7 @@ export class EmailController {
         private readonly emailService: EmailService,
         private smtpService: SmtpService,
         private configService: ConfigService<null, true>,
+        private jobService: JobService,
     ) {}
 
     onModuleInit() {
@@ -139,6 +141,17 @@ export class EmailController {
                 dto.subject,
                 dto.body,
             );
+
+            if (dto.jobId) {
+                this.jobService
+                    .markHandledInternal(dto.jobId, true)
+                    .catch((error: unknown) =>
+                        Logger.warn(
+                            "Failed to mark job as handled after email send",
+                            error,
+                        ),
+                    );
+            }
 
             return true;
         } catch (error) {

--- a/apps/backend/src/email/email.module.ts
+++ b/apps/backend/src/email/email.module.ts
@@ -1,13 +1,14 @@
 import { Module } from "@nestjs/common";
 import { ConfigModule } from "@nestjs/config";
 import { AiBackendModule } from "../ai-backend/ai-backend.module";
+import { JobModule } from "../job/job.module";
 import { PrismaModule } from "../prisma/prisma.module";
 import { SmtpModule } from "../smtp/smtp.module";
 import { EmailController } from "./email.controller";
 import { EmailService } from "./email.service";
 
 @Module({
-    imports: [AiBackendModule, PrismaModule, SmtpModule, ConfigModule],
+    imports: [AiBackendModule, PrismaModule, SmtpModule, ConfigModule, JobModule],
     controllers: [EmailController],
     providers: [EmailService],
 })

--- a/apps/backend/src/email/email.module.ts
+++ b/apps/backend/src/email/email.module.ts
@@ -8,7 +8,13 @@ import { EmailController } from "./email.controller";
 import { EmailService } from "./email.service";
 
 @Module({
-    imports: [AiBackendModule, PrismaModule, SmtpModule, ConfigModule, JobModule],
+    imports: [
+        AiBackendModule,
+        PrismaModule,
+        SmtpModule,
+        ConfigModule,
+        JobModule,
+    ],
     controllers: [EmailController],
     providers: [EmailService],
 })

--- a/apps/backend/src/email/email.service.ts
+++ b/apps/backend/src/email/email.service.ts
@@ -32,35 +32,43 @@ export class EmailService {
             );
             const now = new Date();
 
-            await this.prismaService.$transaction(async (transaction) => {
-                const email = await transaction.email.create({
-                    data: {
-                        userId,
-                        subject: dto.subject?.trim() || null,
-                        body: dto.body,
-                    },
-                });
+            const createdJobId = await this.prismaService.$transaction(
+                async (transaction) => {
+                    const email = await transaction.email.create({
+                        data: {
+                            userId,
+                            subject: dto.subject?.trim() || null,
+                            body: dto.body,
+                        },
+                    });
 
-                const job = await transaction.job.create({
-                    data: {
-                        userId,
-                        emailId: email.id,
-                        status: JobStatus.COMPLETED,
-                        startedAt: now,
-                        completedAt: now,
-                    },
-                });
+                    const job = await transaction.job.create({
+                        data: {
+                            userId,
+                            emailId: email.id,
+                            status: JobStatus.COMPLETED,
+                            startedAt: now,
+                            completedAt: now,
+                        },
+                    });
 
-                await transaction.jobResult.create({
-                    data: {
-                        jobId: job.id,
-                        status: JobResultStatus.SUCCESS,
-                        output: analysisResult as unknown as Prisma.InputJsonValue,
-                    },
-                });
-            });
+                    await transaction.jobResult.create({
+                        data: {
+                            jobId: job.id,
+                            status: JobResultStatus.SUCCESS,
+                            output: analysisResult as unknown as Prisma.InputJsonValue,
+                        },
+                    });
 
-            return { data: analysisResult, email_response_sent: false };
+                    return job.id;
+                },
+            );
+
+            return {
+                data: analysisResult,
+                email_response_sent: false,
+                jobId: createdJobId,
+            };
         } catch (error) {
             if (error instanceof HttpException) {
                 throw error;

--- a/apps/backend/src/email/email.service.ts
+++ b/apps/backend/src/email/email.service.ts
@@ -37,6 +37,7 @@ export class EmailService {
                     const email = await transaction.email.create({
                         data: {
                             userId,
+                            sender: dto.sender ?? null,
                             subject: dto.subject?.trim() || null,
                             body: dto.body,
                         },

--- a/apps/backend/src/job/dto/job-history-entry.dto.ts
+++ b/apps/backend/src/job/dto/job-history-entry.dto.ts
@@ -22,6 +22,15 @@ export class JobHistoryEntryDto {
     id!: string;
 
     @ApiPropertyOptional({
+        description: "Sender address of the email.",
+        type: String,
+        nullable: true,
+    })
+    @IsOptional()
+    @IsString()
+    sender?: string | null;
+
+    @ApiPropertyOptional({
         description: "Email subject submitted for analysis.",
         type: String,
         nullable: true,

--- a/apps/backend/src/job/dto/job-history-entry.dto.ts
+++ b/apps/backend/src/job/dto/job-history-entry.dto.ts
@@ -1,5 +1,6 @@
 import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
 import {
+    IsBoolean,
     IsDateString,
     IsEnum,
     IsObject,
@@ -60,4 +61,11 @@ export class JobHistoryEntryDto {
     })
     @IsEnum(EmailSource)
     source!: EmailSource;
+
+    @ApiProperty({
+        description: "Whether this job has been marked as handled.",
+        type: Boolean,
+    })
+    @IsBoolean()
+    handled!: boolean;
 }

--- a/apps/backend/src/job/dto/update-job-handled.dto.ts
+++ b/apps/backend/src/job/dto/update-job-handled.dto.ts
@@ -1,0 +1,11 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { IsBoolean } from "class-validator";
+
+export class UpdateJobHandledDto {
+    @ApiProperty({
+        description: "Handled status to set for the job.",
+        type: Boolean,
+    })
+    @IsBoolean()
+    handled!: boolean;
+}

--- a/apps/backend/src/job/job.controller.ts
+++ b/apps/backend/src/job/job.controller.ts
@@ -1,4 +1,12 @@
-import { Controller, Get, Param, ParseEnumPipe, Query } from "@nestjs/common";
+import {
+    Body,
+    Controller,
+    Get,
+    Param,
+    ParseEnumPipe,
+    Patch,
+    Query,
+} from "@nestjs/common";
 import {
     ApiCookieAuth,
     ApiOperation,
@@ -11,6 +19,7 @@ import { EmailSource, JobStatus } from "../../prisma/client/enums"; // Separate 
 import { JobResultDto } from "../job-result/dto/job-result.dto";
 import { JobDto } from "./dto/job.dto";
 import { JobHistoryEntryDto } from "./dto/job-history-entry.dto";
+import { UpdateJobHandledDto } from "./dto/update-job-handled.dto";
 import { JobService } from "./job.service";
 
 @ApiTags("Jobs")
@@ -71,6 +80,24 @@ export class JobController {
         @Param("jobId") jobId: string,
     ): Promise<JobDto> {
         return this.jobService.getJobById(session, jobId);
+    }
+
+    @Patch(":jobId/handled")
+    @ApiCookieAuth("apiKeyCookie")
+    @ApiOperation({ summary: "Set handled status for a job" })
+    @ApiResponse({
+        status: 200,
+        description: "Handled status updated.",
+        type: JobHistoryEntryDto,
+    })
+    @ApiResponse({ status: 401, description: "Unauthorized" })
+    @ApiResponse({ status: 404, description: "Job not found" })
+    setJobHandled(
+        @Session() session: UserSession,
+        @Param("jobId") jobId: string,
+        @Body() dto: UpdateJobHandledDto,
+    ): Promise<JobHistoryEntryDto> {
+        return this.jobService.setHandled(session, jobId, dto.handled);
     }
 
     @Get(":jobId/result")

--- a/apps/backend/src/job/job.module.ts
+++ b/apps/backend/src/job/job.module.ts
@@ -7,5 +7,6 @@ import { JobService } from "./job.service";
     imports: [PrismaModule],
     controllers: [JobController],
     providers: [JobService],
+    exports: [JobService],
 })
 export class JobModule {}

--- a/apps/backend/src/job/job.service.ts
+++ b/apps/backend/src/job/job.service.ts
@@ -239,10 +239,7 @@ export class JobService {
      * Sets the handled status for a job without user-scoping.
      * For internal use only — called by trusted server-side processes.
      */
-    async markHandledInternal(
-        jobId: string,
-        handled: boolean,
-    ): Promise<void> {
+    async markHandledInternal(jobId: string, handled: boolean): Promise<void> {
         await this.prismaService.job.update({
             where: { id: jobId },
             data: { handled },

--- a/apps/backend/src/job/job.service.ts
+++ b/apps/backend/src/job/job.service.ts
@@ -209,6 +209,46 @@ export class JobService {
         };
     }
 
+    /**
+     * Sets the handled status for a job owned by the active user.
+     */
+    async setHandled(
+        session: UserSession,
+        jobId: string,
+        handled: boolean,
+    ): Promise<JobHistoryEntryDto> {
+        const job = await this.prismaService.job.findFirst({
+            where: this.getScopedJobIdWhere(session, jobId),
+            include: { email: true, result: true },
+        });
+
+        if (!job) {
+            throw new NotFoundException("Job not found");
+        }
+
+        const updated = await this.prismaService.job.update({
+            where: { id: jobId },
+            data: { handled },
+            include: { email: true, result: true },
+        });
+
+        return this.toJobHistoryEntryDto(updated);
+    }
+
+    /**
+     * Sets the handled status for a job without user-scoping.
+     * For internal use only — called by trusted server-side processes.
+     */
+    async markHandledInternal(
+        jobId: string,
+        handled: boolean,
+    ): Promise<void> {
+        await this.prismaService.job.update({
+            where: { id: jobId },
+            data: { handled },
+        });
+    }
+
     private toJobHistoryEntryDto(job: JobWithRelations): JobHistoryEntryDto {
         return {
             id: job.id,
@@ -217,6 +257,7 @@ export class JobService {
             result: this.toHistoryResult(job.result?.output),
             createdAt: job.createdAt.toISOString(),
             source: job.email.source,
+            handled: job.handled,
         };
     }
 

--- a/apps/backend/src/job/job.service.ts
+++ b/apps/backend/src/job/job.service.ts
@@ -252,6 +252,7 @@ export class JobService {
     private toJobHistoryEntryDto(job: JobWithRelations): JobHistoryEntryDto {
         return {
             id: job.id,
+            sender: job.email.sender,
             subject: job.email.subject,
             body: job.email.body,
             result: this.toHistoryResult(job.result?.output),

--- a/apps/frontend/src/components/composites/views/analyze/output/result/email-response-section.tsx
+++ b/apps/frontend/src/components/composites/views/analyze/output/result/email-response-section.tsx
@@ -7,9 +7,12 @@ import { StyledButton } from "@/components/ui/styled-button";
 import {
     type CreateEmailDto,
     type SubmitEmailResponseDto,
+    getJobControllerGetHistoryQueryKey,
     useEmailControllerSendEmailResponse,
+    useJobControllerSetJobHandled,
 } from "@/lib/client";
 import { showPersistentErrorToast, showSuccessToast } from "@/lib/toast";
+import { useQueryClient } from "@tanstack/react-query";
 
 type SendEmailResponseToast = {
     title: string;
@@ -73,6 +76,10 @@ export function EmailResponseSection({
 }: EmailResponseSectionProps) {
     const response = result.data.email_response;
 
+    const queryClient = useQueryClient();
+
+    const { mutate: setHandled } = useJobControllerSetJobHandled();
+
     const { mutate, isPending } = useEmailControllerSendEmailResponse({
         mutation: {
             onSuccess: (response) => {
@@ -85,6 +92,31 @@ export function EmailResponseSection({
                             },
                     );
                     showSuccessToast({ title: "Email Response Sent" });
+
+                    setHandled(
+                        { jobId: result.jobId, data: { handled: true } },
+                        {
+                            onSuccess: () => {
+                                void queryClient.invalidateQueries({
+                                    queryKey:
+                                        getJobControllerGetHistoryQueryKey({}),
+                                });
+                                void queryClient.invalidateQueries({
+                                    queryKey:
+                                        getJobControllerGetHistoryQueryKey({
+                                            source: "MANUAL",
+                                        }),
+                                });
+                                void queryClient.invalidateQueries({
+                                    queryKey:
+                                        getJobControllerGetHistoryQueryKey({
+                                            source: "IMAP",
+                                        }),
+                                });
+                            },
+                        },
+                    );
+
                     return;
                 }
 
@@ -110,6 +142,7 @@ export function EmailResponseSection({
                     ? `Re: ${request.subject}`
                     : response?.response_subject || "Support Response",
                 body: response.response_body,
+                jobId: result.jobId,
             },
         });
     };

--- a/apps/frontend/src/components/composites/views/analyze/output/result/email-response-section.tsx
+++ b/apps/frontend/src/components/composites/views/analyze/output/result/email-response-section.tsx
@@ -1,3 +1,4 @@
+import { useQueryClient } from "@tanstack/react-query";
 import { Check } from "lucide-react";
 import type { Dispatch, SetStateAction } from "react";
 import { CopyActionButton } from "@/components/composites/views/analyze/output/common/copy-action-button";
@@ -6,13 +7,12 @@ import { ResultSection } from "@/components/composites/views/analyze/output/resu
 import { StyledButton } from "@/components/ui/styled-button";
 import {
     type CreateEmailDto,
-    type SubmitEmailResponseDto,
     getJobControllerGetHistoryQueryKey,
+    type SubmitEmailResponseDto,
     useEmailControllerSendEmailResponse,
     useJobControllerSetJobHandled,
 } from "@/lib/client";
 import { showPersistentErrorToast, showSuccessToast } from "@/lib/toast";
-import { useQueryClient } from "@tanstack/react-query";
 
 type SendEmailResponseToast = {
     title: string;

--- a/apps/frontend/src/components/composites/views/history/history-list-item.tsx
+++ b/apps/frontend/src/components/composites/views/history/history-list-item.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { CheckCheck } from "lucide-react";
-import { Inbox, Mail } from "lucide-react";
+import { CheckCheck, Inbox, Mail } from "lucide-react";
 import { Badge } from "@/components/primitives/badge";
 
 type EmailSource = "MANUAL" | "IMAP";

--- a/apps/frontend/src/components/composites/views/history/history-list-item.tsx
+++ b/apps/frontend/src/components/composites/views/history/history-list-item.tsx
@@ -1,6 +1,8 @@
 "use client";
 
+import { CheckCheck } from "lucide-react";
 import { Inbox, Mail } from "lucide-react";
+import { Badge } from "@/components/primitives/badge";
 
 type EmailSource = "MANUAL" | "IMAP";
 
@@ -9,18 +11,21 @@ type HistoryEntry = {
     subject: string;
     body: string;
     source?: EmailSource;
+    handled: boolean;
 };
 
 type HistoryListItemProps = {
     entry: HistoryEntry;
     isSelected: boolean;
     onSelectAction: (id: string) => void;
+    onToggleHandled: (id: string, handled: boolean) => void;
 };
 
 export function HistoryListItem({
     entry,
     isSelected,
     onSelectAction,
+    onToggleHandled,
 }: HistoryListItemProps) {
     return (
         <button
@@ -48,11 +53,36 @@ export function HistoryListItem({
                     <p className="mt-1 line-clamp-2 text-sm text-slate-600 dark:text-slate-300">
                         {entry.body || "No content preview available."}
                     </p>
-                    <p className="mt-2 text-xs text-slate-400 dark:text-slate-500">
-                        {entry.source === "IMAP"
-                            ? "IMAP Import"
-                            : "Manual Entry"}
-                    </p>
+                    <div className="mt-2 flex items-center justify-between">
+                        <p className="text-xs text-slate-400 dark:text-slate-500">
+                            {entry.source === "IMAP"
+                                ? "IMAP Import"
+                                : "Manual Entry"}
+                        </p>
+                        <div className="flex items-center gap-2">
+                            {entry.handled && (
+                                <Badge className="bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-300">
+                                    <CheckCheck className="h-3 w-3" />
+                                    Handled
+                                </Badge>
+                            )}
+                            <button
+                                type="button"
+                                onClick={(e) => {
+                                    e.stopPropagation();
+                                    onToggleHandled(entry.id, !entry.handled);
+                                }}
+                                className="text-xs text-slate-400 hover:text-slate-600 dark:hover:text-slate-200"
+                                aria-label={
+                                    entry.handled
+                                        ? "Mark as unhandled"
+                                        : "Mark as handled"
+                                }
+                            >
+                                {entry.handled ? "Unmark" : "Mark handled"}
+                            </button>
+                        </div>
+                    </div>
                 </div>
             </div>
         </button>

--- a/apps/frontend/src/components/composites/views/history/history-view.tsx
+++ b/apps/frontend/src/components/composites/views/history/history-view.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useQueryClient } from "@tanstack/react-query";
 import { CheckCheck, FileJson, Inbox, Mail, Search } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import type { AnalysisResult } from "@/components/composites/views/analyze/model/analysis-result";
@@ -17,7 +18,6 @@ import {
 } from "@/lib/client";
 import { showPersistentErrorToast } from "@/lib/toast";
 import { cn } from "@/lib/utils/shadcn-helper";
-import { useQueryClient } from "@tanstack/react-query";
 import { HistoryAnalysisPanel } from "./history-analysis-panel";
 import { HistoryListItem } from "./history-list-item";
 
@@ -215,7 +215,7 @@ export function HistoryView({ history = [] }: HistoryViewProps) {
             email_response_sent: selectedItem.handled,
             jobId: selectedItem.id,
         });
-    }, [selectedItem?.id, selectedItem?.handled]);
+    }, [selectedItem?.id, selectedItem?.handled, selectedItem?.result]);
 
     const tabConfig: {
         key: EmailSource | "ALL";
@@ -285,9 +285,7 @@ export function HistoryView({ history = [] }: HistoryViewProps) {
                                 <button
                                     key={filter.key}
                                     type="button"
-                                    onClick={() =>
-                                        setHandledFilter(filter.key)
-                                    }
+                                    onClick={() => setHandledFilter(filter.key)}
                                     className={cn(
                                         "flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition-colors",
                                         isActive

--- a/apps/frontend/src/components/composites/views/history/history-view.tsx
+++ b/apps/frontend/src/components/composites/views/history/history-view.tsx
@@ -3,6 +3,7 @@
 import { CheckCheck, FileJson, Inbox, Mail, Search } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import type { AnalysisResult } from "@/components/composites/views/analyze/model/analysis-result";
+import { EmailResponseSection } from "@/components/composites/views/analyze/output/result/email-response-section";
 import { SplitView } from "@/components/composites/views/split-view/split-view";
 import { SplitViewPane } from "@/components/composites/views/split-view/split-view-pane";
 import { Badge } from "@/components/primitives/badge";
@@ -10,6 +11,7 @@ import { StyledInput } from "@/components/ui/styled-input";
 import {
     getJobControllerGetHistoryQueryKey,
     type JobHistoryEntryDto,
+    type SubmitEmailResponseDto,
     useJobControllerGetHistory,
     useJobControllerSetJobHandled,
 } from "@/lib/client";
@@ -24,6 +26,7 @@ type HandledFilter = "ALL" | "UNHANDLED" | "HANDLED";
 
 type HistoryEntry = {
     id: string;
+    sender: string | null;
     subject: string;
     body: string;
     result: AnalysisResult | null;
@@ -198,6 +201,21 @@ export function HistoryView({ history = [] }: HistoryViewProps) {
     const selectedItem =
         filteredHistory.find((item) => item.id === selectedId) ?? null;
     const selectedRawResult = selectedItem?.rawResult ?? selectedItem?.result;
+
+    const [historyEmailResult, setHistoryEmailResult] =
+        useState<SubmitEmailResponseDto | null>(null);
+
+    useEffect(() => {
+        if (!selectedItem?.result?.email_response) {
+            setHistoryEmailResult(null);
+            return;
+        }
+        setHistoryEmailResult({
+            data: selectedItem.result,
+            email_response_sent: selectedItem.handled,
+            jobId: selectedItem.id,
+        });
+    }, [selectedItem?.id, selectedItem?.handled]);
 
     const tabConfig: {
         key: EmailSource | "ALL";
@@ -378,6 +396,22 @@ export function HistoryView({ history = [] }: HistoryViewProps) {
                                 </p>
                             )}
                         </section>
+
+                        {historyEmailResult && (
+                            <section className="rounded-2xl border border-slate-200 bg-white p-5 dark:border-slate-800 dark:bg-slate-900/60">
+                                <EmailResponseSection
+                                    result={historyEmailResult}
+                                    setResult={setHistoryEmailResult}
+                                    request={{
+                                        body: selectedItem.body,
+                                        subject:
+                                            selectedItem.subject || undefined,
+                                        sender:
+                                            selectedItem.sender ?? undefined,
+                                    }}
+                                />
+                            </section>
+                        )}
                     </div>
                 ) : (
                     <div className="mx-auto flex h-full w-full max-w-md flex-col items-center justify-center text-slate-400 dark:text-slate-500">
@@ -397,6 +431,7 @@ function mapHistoryEntryDtoToHistoryEntry(
 ): HistoryEntry {
     return {
         id: entry.id,
+        sender: entry.sender ?? null,
         subject: entry.subject ?? "",
         body: entry.body,
         result: toHistoryAnalysisResult(entry.result),

--- a/apps/frontend/src/components/composites/views/history/history-view.tsx
+++ b/apps/frontend/src/components/composites/views/history/history-view.tsx
@@ -1,22 +1,26 @@
 "use client";
 
-import { FileJson, Inbox, Mail, Search } from "lucide-react";
+import { CheckCheck, FileJson, Inbox, Mail, Search } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import type { AnalysisResult } from "@/components/composites/views/analyze/model/analysis-result";
 import { SplitView } from "@/components/composites/views/split-view/split-view";
 import { SplitViewPane } from "@/components/composites/views/split-view/split-view-pane";
+import { Badge } from "@/components/primitives/badge";
 import { StyledInput } from "@/components/ui/styled-input";
 import {
     getJobControllerGetHistoryQueryKey,
     type JobHistoryEntryDto,
     useJobControllerGetHistory,
+    useJobControllerSetJobHandled,
 } from "@/lib/client";
 import { showPersistentErrorToast } from "@/lib/toast";
 import { cn } from "@/lib/utils/shadcn-helper";
+import { useQueryClient } from "@tanstack/react-query";
 import { HistoryAnalysisPanel } from "./history-analysis-panel";
 import { HistoryListItem } from "./history-list-item";
 
 type EmailSource = "MANUAL" | "IMAP";
+type HandledFilter = "ALL" | "UNHANDLED" | "HANDLED";
 
 type HistoryEntry = {
     id: string;
@@ -25,6 +29,7 @@ type HistoryEntry = {
     result: AnalysisResult | null;
     rawResult?: unknown | null;
     source: EmailSource;
+    handled: boolean;
 };
 
 type HistoryViewProps = {
@@ -50,6 +55,7 @@ export function HistoryView({ history = [] }: HistoryViewProps) {
     const [selectedSource, setSelectedSource] = useState<EmailSource | "ALL">(
         "ALL",
     );
+    const [handledFilter, setHandledFilter] = useState<HandledFilter>("ALL");
 
     const hasProvidedHistory = history.length > 0;
 
@@ -122,10 +128,15 @@ export function HistoryView({ history = [] }: HistoryViewProps) {
     );
     const [query, setQuery] = useState("");
 
-    const filteredHistory = useMemo(
-        () => filterEntries(sourceHistory, query),
-        [sourceHistory, query],
-    );
+    const filteredHistory = useMemo(() => {
+        let entries = filterEntries(sourceHistory, query);
+        if (handledFilter === "HANDLED") {
+            entries = entries.filter((e) => e.handled);
+        } else if (handledFilter === "UNHANDLED") {
+            entries = entries.filter((e) => !e.handled);
+        }
+        return entries;
+    }, [sourceHistory, query, handledFilter]);
 
     useEffect(() => {
         if (filteredHistory.length === 0) {
@@ -152,6 +163,38 @@ export function HistoryView({ history = [] }: HistoryViewProps) {
         }
     }, [currentQuery.isError, hasProvidedHistory]);
 
+    const queryClient = useQueryClient();
+
+    const { mutate: setHandled } = useJobControllerSetJobHandled({
+        mutation: {
+            onSuccess: () => {
+                void queryClient.invalidateQueries({
+                    queryKey: getJobControllerGetHistoryQueryKey({}),
+                });
+                void queryClient.invalidateQueries({
+                    queryKey: getJobControllerGetHistoryQueryKey({
+                        source: "MANUAL",
+                    }),
+                });
+                void queryClient.invalidateQueries({
+                    queryKey: getJobControllerGetHistoryQueryKey({
+                        source: "IMAP",
+                    }),
+                });
+            },
+            onError: () => {
+                showPersistentErrorToast({
+                    title: "Failed to Update",
+                    description: "Could not update handled status.",
+                });
+            },
+        },
+    });
+
+    const handleToggleHandled = (id: string, handled: boolean) => {
+        setHandled({ jobId: id, data: { handled } });
+    };
+
     const selectedItem =
         filteredHistory.find((item) => item.id === selectedId) ?? null;
     const selectedRawResult = selectedItem?.rawResult ?? selectedItem?.result;
@@ -165,6 +208,12 @@ export function HistoryView({ history = [] }: HistoryViewProps) {
         { key: "ALL", label: "All", icon: Mail },
         { key: "MANUAL", label: "Manual", icon: Mail },
         { key: "IMAP", label: "IMAP", icon: Inbox },
+    ];
+
+    const handledFilterConfig: { key: HandledFilter; label: string }[] = [
+        { key: "ALL", label: "All" },
+        { key: "UNHANDLED", label: "Unhandled" },
+        { key: "HANDLED", label: "Handled" },
     ];
 
     const isLoading = currentQuery.isLoading && !hasProvidedHistory;
@@ -185,7 +234,7 @@ export function HistoryView({ history = [] }: HistoryViewProps) {
                     </div>
 
                     {/* Source Tabs */}
-                    <div className="mb-6 flex gap-2">
+                    <div className="mb-3 flex gap-2">
                         {tabConfig.map((tab) => {
                             const Icon = tab.icon;
                             const isActive = selectedSource === tab.key;
@@ -204,6 +253,34 @@ export function HistoryView({ history = [] }: HistoryViewProps) {
                                 >
                                     <Icon className="h-4 w-4" />
                                     {tab.label}
+                                </button>
+                            );
+                        })}
+                    </div>
+
+                    {/* Handled Filter */}
+                    <div className="mb-6 flex gap-2">
+                        {handledFilterConfig.map((filter) => {
+                            const isActive = handledFilter === filter.key;
+
+                            return (
+                                <button
+                                    key={filter.key}
+                                    type="button"
+                                    onClick={() =>
+                                        setHandledFilter(filter.key)
+                                    }
+                                    className={cn(
+                                        "flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition-colors",
+                                        isActive
+                                            ? "bg-green-600 text-white"
+                                            : "bg-slate-100 text-slate-600 hover:bg-slate-200 dark:bg-slate-800 dark:text-slate-400 dark:hover:bg-slate-700",
+                                    )}
+                                >
+                                    {filter.key === "HANDLED" && (
+                                        <CheckCheck className="h-3 w-3" />
+                                    )}
+                                    {filter.label}
                                 </button>
                             );
                         })}
@@ -239,6 +316,7 @@ export function HistoryView({ history = [] }: HistoryViewProps) {
                                     entry={entry}
                                     isSelected={entry.id === selectedItem?.id}
                                     onSelectAction={setSelectedId}
+                                    onToggleHandled={handleToggleHandled}
                                 />
                             ))
                         ) : (
@@ -254,17 +332,25 @@ export function HistoryView({ history = [] }: HistoryViewProps) {
                 {selectedItem ? (
                     <div className="mx-auto flex min-h-full w-full flex-col gap-4">
                         <section className="rounded-2xl border border-slate-200 bg-white p-5 dark:border-slate-800 dark:bg-slate-900/60">
-                            <div className="mb-4 flex items-center gap-2">
-                                {selectedItem.source === "IMAP" ? (
-                                    <Inbox className="h-5 w-5 text-purple-500 dark:text-purple-400" />
-                                ) : (
-                                    <Mail className="h-5 w-5 text-blue-500 dark:text-blue-400" />
+                            <div className="mb-4 flex items-center justify-between">
+                                <div className="flex items-center gap-2">
+                                    {selectedItem.source === "IMAP" ? (
+                                        <Inbox className="h-5 w-5 text-purple-500 dark:text-purple-400" />
+                                    ) : (
+                                        <Mail className="h-5 w-5 text-blue-500 dark:text-blue-400" />
+                                    )}
+                                    <span className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                                        {selectedItem.source === "IMAP"
+                                            ? "IMAP Import"
+                                            : "Manual Entry"}
+                                    </span>
+                                </div>
+                                {selectedItem.handled && (
+                                    <Badge className="bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-300">
+                                        <CheckCheck className="h-3 w-3" />
+                                        Handled
+                                    </Badge>
                                 )}
-                                <span className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
-                                    {selectedItem.source === "IMAP"
-                                        ? "IMAP Import"
-                                        : "Manual Entry"}
-                                </span>
                             </div>
                             <h2 className="text-xl font-semibold text-slate-900 dark:text-white">
                                 {selectedItem.subject || "Untitled mail"}
@@ -316,6 +402,7 @@ function mapHistoryEntryDtoToHistoryEntry(
         result: toHistoryAnalysisResult(entry.result),
         rawResult: entry.result ?? null,
         source: entry.source ?? "MANUAL",
+        handled: entry.handled,
     };
 }
 

--- a/wiki/Architecture.md
+++ b/wiki/Architecture.md
@@ -33,14 +33,33 @@ The diagram asset is generated from `wiki/assets/database_schema.d2`.
 
 Email analysis and history are now part of one end-to-end backend/frontend flow:
 
-1. `POST /api/emails` runs AI analysis and persists `Email`, `Job` (`COMPLETED`), and `JobResult` in one transaction.
+1. `POST /api/emails` runs AI analysis and persists `Email`, `Job` (`COMPLETED`), and `JobResult` in one transaction. The sender address from the request is stored on the `Email` record so it is available later for sending a response from the history view.
 2. `GET /api/jobs/history` returns completed history entries (newest first, up to 100 items), optionally filtered by `source=MANUAL|IMAP`.
 3. Visibility is source-aware:
    - IMAP entries are instance-wide and visible to all users.
    - Manual entries remain user-scoped in the default combined view.
    - `source=MANUAL` applies role-based access (admins can inspect all manual entries).
-4. Frontend `History` view provides source tabs (`All`, `Manual`, `IMAP`), subject/body search, and detailed result inspection.
+4. Frontend `History` view provides source tabs (`All`, `Manual`, `IMAP`), a handled-status filter (`All`, `Unhandled`, `Handled`), subject/body search, and detailed result inspection.
 5. Each history card is labeled by source (`Manual Entry` / `IMAP Import`) so users can distinguish ingestion origin.
+
+### Handled status
+
+Every `Job` carries a `handled` boolean (`false` by default). It tracks whether a mail has been acted upon.
+
+**How a job becomes handled:**
+
+- **Automatic** — when a user sends the generated email response via the `Send Email Response` button (in either the `Analyze` or `History` view), the backend marks the corresponding job as handled immediately after the SMTP send succeeds.
+- **Manual** — any user can toggle the handled state directly from the history list with the `Mark handled` / `Unmark` button on each card.
+
+**API:**
+
+- `PATCH /api/jobs/:jobId/handled` — sets `{ handled: true|false }` on the job. Scoped to the requesting user (admins can update any job).
+
+**Frontend behaviour:**
+
+- Handled jobs show a green `Handled` badge in the history list and in the detail panel header.
+- The `Handled` / `Unhandled` filter tabs let users focus on mails that still need attention.
+- The `Send Email Response` button in the history detail panel is shown whenever the analysis result contains a generated email response and a sender address is known. After a successful send the button is replaced by a confirmation indicator and the job is marked handled.
 
 ## IMAP integration flow
 

--- a/wiki/Architecture.md
+++ b/wiki/Architecture.md
@@ -33,13 +33,16 @@ The diagram asset is generated from `wiki/assets/database_schema.d2`.
 
 Email analysis and history are now part of one end-to-end backend/frontend flow:
 
-1. `POST /api/emails` runs AI analysis and persists `Email`, `Job` (`COMPLETED`), and `JobResult` in one transaction. The sender address from the request is stored on the `Email` record so it is available later for sending a response from the history view.
+1. `POST /api/emails` runs AI analysis and persists `Email`, `Job` (`COMPLETED`), and `JobResult` in one transaction.
+   The sender address from the request is stored on the `Email` record so it is available later for sending
+   a response from the history view.
 2. `GET /api/jobs/history` returns completed history entries (newest first, up to 100 items), optionally filtered by `source=MANUAL|IMAP`.
 3. Visibility is source-aware:
    - IMAP entries are instance-wide and visible to all users.
    - Manual entries remain user-scoped in the default combined view.
    - `source=MANUAL` applies role-based access (admins can inspect all manual entries).
-4. Frontend `History` view provides source tabs (`All`, `Manual`, `IMAP`), a handled-status filter (`All`, `Unhandled`, `Handled`), subject/body search, and detailed result inspection.
+4. Frontend `History` view provides source tabs (`All`, `Manual`, `IMAP`), a handled-status filter
+   (`All`, `Unhandled`, `Handled`), subject/body search, and detailed result inspection.
 5. Each history card is labeled by source (`Manual Entry` / `IMAP Import`) so users can distinguish ingestion origin.
 
 ### Handled status
@@ -48,7 +51,9 @@ Every `Job` carries a `handled` boolean (`false` by default). It tracks whether 
 
 **How a job becomes handled:**
 
-- **Automatic** — when a user sends the generated email response via the `Send Email Response` button (in either the `Analyze` or `History` view), the backend marks the corresponding job as handled immediately after the SMTP send succeeds.
+- **Automatic** — when a user sends the generated email response via the `Send Email Response` button
+  (in either the `Analyze` or `History` view), the backend marks the corresponding job as handled
+  immediately after the SMTP send succeeds.
 - **Manual** — any user can toggle the handled state directly from the history list with the `Mark handled` / `Unmark` button on each card.
 
 **API:**
@@ -59,7 +64,9 @@ Every `Job` carries a `handled` boolean (`false` by default). It tracks whether 
 
 - Handled jobs show a green `Handled` badge in the history list and in the detail panel header.
 - The `Handled` / `Unhandled` filter tabs let users focus on mails that still need attention.
-- The `Send Email Response` button in the history detail panel is shown whenever the analysis result contains a generated email response and a sender address is known. After a successful send the button is replaced by a confirmation indicator and the job is marked handled.
+- The `Send Email Response` button in the history detail panel is shown whenever the analysis result
+  contains a generated email response and a sender address is known. After a successful send the button
+  is replaced by a confirmation indicator and the job is marked handled.
 
 ## IMAP integration flow
 

--- a/wiki/Getting-Started.md
+++ b/wiki/Getting-Started.md
@@ -209,5 +209,8 @@ The `History` view lists all completed analysis runs. For each entry you can:
 - **Filter by source** — switch between `All`, `Manual`, and `IMAP` tabs.
 - **Filter by handled status** — switch between `All`, `Unhandled`, and `Handled` tabs to focus on mails that still need a response.
 - **Search** — filter entries by subject or body content.
-- **Send a response** — if the analysis produced a suggested email response and the original sender address is known, a `Send Email Response` button appears in the detail panel. Clicking it sends the response via SMTP and automatically marks the mail as handled.
-- **Toggle handled manually** — use the `Mark handled` / `Unmark` button on any history card to set or clear the handled status without sending an email.
+- **Send a response** — if the analysis produced a suggested email response and the original sender address
+  is known, a `Send Email Response` button appears in the detail panel. Clicking it sends the response via
+  SMTP and automatically marks the mail as handled.
+- **Toggle handled manually** — use the `Mark handled` / `Unmark` button on any history card to set or
+  clear the handled status without sending an email.

--- a/wiki/Getting-Started.md
+++ b/wiki/Getting-Started.md
@@ -201,3 +201,13 @@ For a practical quick-start and full technical reference for category configurat
 3. Use the `IMAP` view to preview inbox emails and analyze selected messages.
 4. Processed emails are moved to the `ai_analyzed` folder and appear in `History` with source label `IMAP Import`.
 5. If automatic processing is enabled in Mail settings, new inbox emails are imported and analyzed periodically.
+
+## Working with the history view
+
+The `History` view lists all completed analysis runs. For each entry you can:
+
+- **Filter by source** — switch between `All`, `Manual`, and `IMAP` tabs.
+- **Filter by handled status** — switch between `All`, `Unhandled`, and `Handled` tabs to focus on mails that still need a response.
+- **Search** — filter entries by subject or body content.
+- **Send a response** — if the analysis produced a suggested email response and the original sender address is known, a `Send Email Response` button appears in the detail panel. Clicking it sends the response via SMTP and automatically marks the mail as handled.
+- **Toggle handled manually** — use the `Mark handled` / `Unmark` button on any history card to set or clear the handled status without sending an email.


### PR DESCRIPTION
Closes #299

## Summary

- Adds a `handled` boolean field to the `Job` model to track whether a mail has been acted upon
- Automatically marks a job as handled when an email response is sent (via Analyze or History view)
- Users can manually toggle the handled status per history entry
- History view gains a handled-status filter (`All` / `Unhandled` / `Handled`) and a green badge on handled entries
- The `Send Email Response` button from the Analyze view is reused in the History detail panel
- Fixes a pre-existing bug where the sender address was not persisted when creating an email, which prevented the response button from appearing in history

## Changes

**Backend**
- `prisma/schema.prisma` — `handled Boolean @default(false)` on `Job`
- `JobHistoryEntryDto` — adds `handled` and `sender` fields
- New `PATCH /api/jobs/:jobId/handled` endpoint (user-scoped)
- `SubmitEmailResponseDto` — adds `jobId` so the frontend can reference the job after analysis
- `email.service.ts` — persists `sender` on email creation; returns `jobId` in response
- `email.controller.ts` — auto-marks job as handled after successful SMTP send

**Frontend**
- History list item: handled badge + mark/unmark toggle button
- History view: handled-status filter row, toggle mutation with cache invalidation, badge in detail panel
- History detail panel: reuses `EmailResponseSection` to send responses directly from history
- Analyze view: calls `setHandled` after successful email response send

**Docs**
- `wiki/Architecture.md` — new "Handled status" subsection
- `wiki/Getting-Started.md` — new "Working with the history view" section

## Test plan

- [x] Submit a manual email with a sender address in the Analyze view → send the response → verify history entry shows `Handled` badge
- [x] Navigate to History → verify `Unhandled` filter hides the handled entry, `Handled` filter shows it
- [x] Use `Mark handled` toggle on an unhandled entry → badge appears; use `Unmark` → badge disappears
- [x] Open a history entry with a generated response and known sender → verify `Send Email Response` button is present → send it → verify job is marked handled
- [x] Verify entries without a sender address do not show the response button in history
