### PR TITLE
fix(#317): reliable IMAP auto-import (UID tracking, toast, history)

### DIFF
--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -133,7 +133,8 @@ model InstanceSettings {
     imapEnabled             Boolean   @default(false)
     imapIsConnected         Boolean   @default(false)
     imapLastSyncedAt        DateTime?
-    imapAutoProcessEnabled  Boolean   @default(false)
+    imapAutoProcessEnabled   Boolean   @default(false)
+    imapAutoProcessEnabledAt DateTime?
     createdAt        DateTime  @default(now())
     updatedAt        DateTime  @updatedAt
 

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -133,6 +133,7 @@ model InstanceSettings {
     imapEnabled             Boolean   @default(false)
     imapIsConnected         Boolean   @default(false)
     imapLastSyncedAt        DateTime?
+    imapLastUid             Int       @default(0)
     imapAutoProcessEnabled   Boolean   @default(false)
     imapAutoProcessEnabledAt DateTime?
     createdAt        DateTime  @default(now())

--- a/apps/backend/src/imap/dto/imap-config.dto.ts
+++ b/apps/backend/src/imap/dto/imap-config.dto.ts
@@ -37,4 +37,10 @@ export class ImapConfigDto {
         example: true,
     })
     enabled!: boolean;
+
+    @ApiProperty({
+        description: "Whether to automatically process new incoming emails",
+        example: false,
+    })
+    autoProcessEnabled!: boolean;
 }

--- a/apps/backend/src/imap/imap-poller.service.ts
+++ b/apps/backend/src/imap/imap-poller.service.ts
@@ -200,6 +200,9 @@ export class ImapPollerService {
             },
             logger: false,
         });
+        client.on("error", (err: Error) => {
+            this.logger.error(`[ImapFlow] Socket error in checkForNewEmails: ${err.message}`);
+        });
 
         try {
             await client.connect();
@@ -389,6 +392,9 @@ export class ImapPollerService {
             },
             logger: false,
         });
+        client.on("error", (err: Error) => {
+            this.logger.error(`[ImapFlow] Socket error in getMailboxMessageCount: ${err.message}`);
+        });
 
         try {
             await client.connect();
@@ -428,6 +434,9 @@ export class ImapPollerService {
                     : undefined,
             auth: { user: config.username, pass: config.password },
             logger: false,
+        });
+        client.on("error", (err: Error) => {
+            this.logger.error(`[ImapFlow] Socket error in processExistingEmails: ${err.message}`);
         });
 
         try {
@@ -513,6 +522,9 @@ export class ImapPollerService {
             auth: { user: credentials.username, pass: credentials.password },
             logger: false,
         });
+        client.on("error", (err: Error) => {
+            this.logger.error(`[ImapFlow] Socket error in listFolders: ${err.message}`);
+        });
 
         try {
             await client.connect();
@@ -558,6 +570,9 @@ export class ImapPollerService {
             auth: { user: config.username, pass: config.password },
             logger: false,
         });
+        client.on("error", (err: Error) => {
+            this.logger.error(`[ImapFlow] Socket error in getInboxEmails: ${err.message}`);
+        });
 
         try {
             await client.connect();
@@ -574,10 +589,23 @@ export class ImapPollerService {
             const messages = await client.fetch("1:*", {
                 uid: true,
                 envelope: true,
+                internalDate: true,
             } as unknown as import("imapflow").FetchQueryObject);
+
+            const autoProcessEnabledAt = config.autoProcessEnabledAt;
 
             for await (const message of messages) {
                 if (!message.uid) continue;
+                // When auto-process is enabled, hide emails that arrived after the activation
+                // timestamp — they will be (or already are) auto-processed by the cron job.
+                if (
+                    config.autoProcessEnabled &&
+                    autoProcessEnabledAt &&
+                    message.internalDate &&
+                    message.internalDate >= autoProcessEnabledAt
+                ) {
+                    continue;
+                }
                 emails.push({
                     uid: message.uid,
                     subject: message.envelope?.subject
@@ -624,6 +652,9 @@ export class ImapPollerService {
                     : undefined,
             auth: { user: config.username, pass: config.password },
             logger: false,
+        });
+        client.on("error", (err: Error) => {
+            this.logger.error(`[ImapFlow] Socket error in getEmailBody: ${err.message}`);
         });
 
         try {
@@ -693,6 +724,9 @@ export class ImapPollerService {
                     : undefined,
             auth: { user: config.username, pass: config.password },
             logger: false,
+        });
+        client.on("error", (err: Error) => {
+            this.logger.error(`[ImapFlow] Socket error in analyzeSelectedEmails: ${err.message}`);
         });
 
         let processedCount = 0;
@@ -808,12 +842,6 @@ export class ImapPollerService {
                                     output: analysisResult as unknown as Prisma.InputJsonValue,
                                 },
                             });
-
-                            this.eventEmitter.emit("imap.email.received", {
-                                userId: adminUser.id,
-                                emailId: email.id,
-                                subject,
-                            } as NewImapEmailEvent);
                         },
                     );
 

--- a/apps/backend/src/imap/imap-poller.service.ts
+++ b/apps/backend/src/imap/imap-poller.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger } from "@nestjs/common";
 import { EventEmitter2 } from "@nestjs/event-emitter";
-import { Cron, CronExpression } from "@nestjs/schedule";
+import { Cron } from "@nestjs/schedule";
 import type { Prisma } from "../../prisma/client/client";
 import {
     EmailSource,
@@ -18,6 +18,14 @@ import type {
 } from "./dto";
 import { ImapConfig, ImapService } from "./imap.service";
 
+interface DetectedEmail {
+    uid: number;
+    subject: string;
+    sender: string | null;
+    body: string;
+    messageId: string;
+}
+
 export interface NewImapEmailEvent {
     userId: string;
     emailId: string;
@@ -27,7 +35,7 @@ export interface NewImapEmailEvent {
 @Injectable()
 export class ImapPollerService {
     private readonly logger = new Logger(ImapPollerService.name);
-    private isRunning = false;
+    private isDetecting = false;
     private readonly processingUids = new Set<number>();
     private readonly ANALYZED_FOLDER = "ai_analyzed";
     private analyzedFolderPath: string | null = null;
@@ -41,36 +49,69 @@ export class ImapPollerService {
     ) {}
 
     /**
-     * Polls the IMAP mailbox every minute for new emails.
+     * Polls the IMAP mailbox every 30 seconds for new emails.
+     * Two-phase approach: detection (fast, IMAP connection) then processing (slow, AI).
      */
-    @Cron(CronExpression.EVERY_MINUTE)
+    @Cron("*/30 * * * * *")
     async pollImapMailbox(): Promise<void> {
-        if (this.isRunning) {
-            return;
-        }
+        if (this.isDetecting) return;
 
         const config = await this.settingsService.getImapConfig();
-        if (!config) {
-            return;
-        }
+        if (!config || !config.autoProcessEnabled) return;
 
         const status = await this.settingsService.getImapStatus();
-        if (!status.isEnabled) {
-            return;
-        }
+        if (!status.isEnabled) return;
 
-        if (!config.autoProcessEnabled) {
-            return;
-        }
-
-        this.isRunning = true;
-
+        // === PHASE 1: Detection (short, IMAP connection is open only here) ===
+        this.isDetecting = true;
+        let emailsToProcess: DetectedEmail[] = [];
+        let maxUid = config.lastUid;
         try {
-            await this.checkForNewEmails(config);
+            const result = await this.detectNewEmails(config);
+            emailsToProcess = result.emails;
+            maxUid = result.maxUid;
+            // Advance lastUid immediately so the next cron cycle doesn't re-detect
+            if (maxUid > config.lastUid) {
+                await this.prismaService.instanceSettings.update({
+                    where: { id: "singleton" },
+                    data: { imapLastUid: maxUid, imapLastSyncedAt: new Date() },
+                });
+            }
+            // Mark all UIDs as in-progress before releasing the detection lock
+            for (const email of emailsToProcess) {
+                this.processingUids.add(email.uid);
+            }
         } catch (error) {
-            this.logger.error("Error polling IMAP mailbox:", error);
+            this.logger.error("IMAP detection failed:", error);
+            return;
         } finally {
-            this.isRunning = false;
+            this.isDetecting = false; // Release lock BEFORE AI analysis starts
+        }
+
+        if (emailsToProcess.length === 0) return;
+
+        // === PHASE 2: Processing (long, no open IMAP connection) ===
+        const adminUser = await this.prismaService.user.findFirst({
+            where: { role: "ADMIN" },
+        });
+        if (!adminUser) {
+            this.logger.warn("No admin user found for IMAP email processing");
+            for (const email of emailsToProcess) {
+                this.processingUids.delete(email.uid);
+            }
+            return;
+        }
+
+        for (const emailData of emailsToProcess) {
+            try {
+                await this.processDetectedEmail(emailData, config, adminUser.id);
+            } catch (error) {
+                this.logger.error(
+                    `[AutoProcess] Failed for uid=${emailData.uid}: ${error instanceof Error ? error.message : String(error)}`,
+                );
+            } finally {
+                this.processingUids.delete(emailData.uid);
+            }
         }
     }
 
@@ -182,9 +223,13 @@ export class ImapPollerService {
     }
 
     /**
-     * Checks for new emails in the IMAP mailbox and processes them.
+     * Detection phase: opens a short-lived IMAP connection, fetches emails with
+     * UID greater than the stored lastUid, closes the connection, and returns
+     * the collected emails together with the highest seen UID.
      */
-    private async checkForNewEmails(config: ImapConfig): Promise<void> {
+    private async detectNewEmails(
+        config: ImapConfig,
+    ): Promise<{ emails: DetectedEmail[]; maxUid: number }> {
         const ImapClient = (await import("imapflow")).ImapFlow;
 
         const client = new ImapClient({
@@ -195,180 +240,259 @@ export class ImapPollerService {
                 config.security === "starttls"
                     ? { rejectUnauthorized: false }
                     : undefined,
-            auth: {
-                user: config.username,
-                pass: config.password,
-            },
+            auth: { user: config.username, pass: config.password },
             logger: false,
         });
         client.on("error", (err: Error) => {
-            this.logger.error(`[ImapFlow] Socket error in checkForNewEmails: ${err.message}`);
+            this.logger.error(
+                `[ImapFlow] Socket error in detectNewEmails: ${err.message}`,
+            );
         });
 
         try {
             await client.connect();
-
-            // Ensure the analyzed folder exists
-            await this.ensureAnalyzedFolderExists(client);
-
-            // Get the last synced UID to avoid reprocessing
-            const settings =
-                await this.prismaService.instanceSettings.findUnique({
-                    where: { id: "singleton" },
-                    select: { imapLastSyncedAt: true },
-                });
-
-            const _mailbox = await client.mailboxOpen(config.mailbox);
-
-            // Search for unread messages
-            const searchCriteria = settings?.imapLastSyncedAt
-                ? { since: settings.imapLastSyncedAt }
-                : { unseen: true };
-
-            const messages = await client.fetch(searchCriteria, {
-                uid: true,
-                envelope: true,
-                source: true,
-                text: true,
-                html: true,
-            } as unknown as import("imapflow").FetchQueryObject);
-
-            let newEmailCount = 0;
-
-            for await (const message of messages) {
-                // Skip messages that are already in the AI-Analyzed folder
-                if (this.isMessageInAnalyzedFolder(message)) {
-                    continue;
-                }
-
-                // Check if this email was already processed
-                const messageId = message.envelope?.messageId || "";
-                const existingEmail = await this.prismaService.email.findFirst({
-                    where: {
-                        source: EmailSource.IMAP,
-                        body: {
-                            contains: messageId,
-                        },
-                    },
-                });
-
-                if (existingEmail) {
-                    continue;
-                }
-
-                // Get admin user for IMAP emails
-                const adminUser = await this.prismaService.user.findFirst({
-                    where: { role: "ADMIN" },
-                });
-
-                if (!adminUser) {
-                    this.logger.warn(
-                        "No admin user found for IMAP email processing",
-                    );
-                    continue;
-                }
-
-                // Parse email content
-                const subject = decodeMailHeader(
-                    message.envelope?.subject || "",
-                );
-                const sender = message.envelope?.from?.[0]?.address || null;
-                const body = decodeQuotedPrintable(
-                    this.extractTextContent(message),
-                );
-
-                // Process email through AI backend and save results
-                try {
-                    const analysisResult = await this.aiBackendService.runFlow(
-                        body,
-                        subject,
-                    );
-                    const now = new Date();
-
-                    await this.prismaService.$transaction(
-                        async (transaction) => {
-                            const email = await transaction.email.create({
-                                data: {
-                                    userId: adminUser.id,
-                                    sender,
-                                    subject,
-                                    body,
-                                    source: EmailSource.IMAP,
-                                },
-                            });
-
-                            const job = await transaction.job.create({
-                                data: {
-                                    userId: adminUser.id,
-                                    emailId: email.id,
-                                    status: JobStatus.COMPLETED,
-                                    startedAt: now,
-                                    completedAt: now,
-                                },
-                            });
-
-                            await transaction.jobResult.create({
-                                data: {
-                                    jobId: job.id,
-                                    status: JobResultStatus.SUCCESS,
-                                    output: analysisResult as unknown as Prisma.InputJsonValue,
-                                },
-                            });
-
-                            newEmailCount++;
-
-                            // Emit event for notification
-                            this.eventEmitter.emit("imap.email.received", {
-                                userId: adminUser.id,
-                                emailId: email.id,
-                                subject,
-                            } as NewImapEmailEvent);
-
-                            this.logger.log(
-                                `New IMAP email processed: ${subject || "(no subject)"}`,
-                            );
-
-                            newEmailCount++;
-                        },
-                    );
-
-                    // Move the message to AI-Analyzed folder AFTER successful transaction
-                    // Note: This happens outside the transaction so DB changes are preserved
-                    // even if the move fails (e.g., due to connection issues with GMX)
-                    if (message.uid) {
-                        try {
-                            await this.moveMessageToAnalyzedFolder(
-                                client,
-                                message.uid,
-                            );
-                        } catch (moveError) {
-                            this.logger.warn(
-                                `Could not move message ${message.uid} to analyzed folder, but email was processed: ${moveError instanceof Error ? moveError.message : String(moveError)}`,
-                            );
-                            // Continue - the email was already saved to DB
-                        }
-                    }
-                } catch (error) {
-                    this.logger.error(
-                        `Failed to process IMAP email: ${subject || "(no subject)"}`,
-                        error,
-                    );
-                }
-            }
-
-            // Update last synced timestamp
-            await this.prismaService.instanceSettings.update({
-                where: { id: "singleton" },
-                data: { imapLastSyncedAt: new Date() },
+            const mailboxInfo = await client.mailboxOpen(config.mailbox, {
+                readOnly: true,
             });
 
-            if (newEmailCount > 0) {
-                this.logger.log(`Processed ${newEmailCount} new IMAP emails`);
+            if (mailboxInfo.exists === 0) {
+                await client.logout();
+                return { emails: [], maxUid: config.lastUid };
+            }
+
+            const lastUid = config.lastUid;
+            const uidRange = `${lastUid + 1}:*`;
+
+            const detected: DetectedEmail[] = [];
+            let maxUid = lastUid;
+
+            const messages = await client.fetch(
+                uidRange,
+                {
+                    uid: true,
+                    envelope: true,
+                    source: true,
+                    text: true,
+                    html: true,
+                } as unknown as import("imapflow").FetchQueryObject,
+                { uid: true },
+            );
+
+            for await (const message of messages) {
+                if (!message.uid) continue;
+                if (message.uid <= lastUid) continue;
+                if (this.processingUids.has(message.uid)) continue;
+
+                if (message.uid > maxUid) maxUid = message.uid;
+
+                const messageId = message.envelope?.messageId || "";
+                if (messageId) {
+                    const existing = await this.prismaService.email.findFirst({
+                        where: {
+                            source: EmailSource.IMAP,
+                            body: { contains: messageId },
+                        },
+                    });
+                    if (existing) continue;
+                }
+
+                detected.push({
+                    uid: message.uid,
+                    subject: decodeMailHeader(
+                        message.envelope?.subject || "",
+                    ),
+                    sender: message.envelope?.from?.[0]?.address ?? null,
+                    body: decodeQuotedPrintable(
+                        this.extractTextContent(message),
+                    ),
+                    messageId,
+                });
             }
 
             await client.logout();
+            return { emails: detected, maxUid };
         } catch (error) {
-            this.logger.error("Error checking IMAP mailbox:", error);
+            try {
+                await client.logout();
+            } catch {
+                /* ignore */
+            }
+            throw error;
+        }
+    }
+
+    /**
+     * Processing phase for a single detected email: AI analysis, DB transaction,
+     * move to ai_analyzed (with fresh IMAP connection), then emit notification.
+     */
+    private async processDetectedEmail(
+        emailData: DetectedEmail,
+        config: ImapConfig,
+        userId: string,
+    ): Promise<void> {
+        // AI analysis runs here — no IMAP connection is open
+        const analysisResult = await this.aiBackendService.runFlow(
+            emailData.body,
+            emailData.subject,
+        );
+        const now = new Date();
+
+        let emailId = "";
+        await this.prismaService.$transaction(async (tx) => {
+            const email = await tx.email.create({
+                data: {
+                    userId,
+                    sender: emailData.sender,
+                    subject: emailData.subject,
+                    body: emailData.body,
+                    source: EmailSource.IMAP,
+                },
+            });
+            emailId = email.id;
+
+            const job = await tx.job.create({
+                data: {
+                    userId,
+                    emailId: email.id,
+                    status: JobStatus.COMPLETED,
+                    startedAt: now,
+                    completedAt: now,
+                },
+            });
+
+            await tx.jobResult.create({
+                data: {
+                    jobId: job.id,
+                    status: JobResultStatus.SUCCESS,
+                    output: analysisResult as unknown as Prisma.InputJsonValue,
+                },
+            });
+        });
+
+        // Move using a fresh IMAP connection — no socket timeout risk
+        try {
+            await this.moveEmailWithFreshConnection(config, emailData.uid);
+        } catch (moveError) {
+            this.logger.warn(
+                `[AutoProcess] Could not move uid=${emailData.uid}: ${moveError instanceof Error ? moveError.message : String(moveError)}`,
+            );
+        }
+
+        // Emit notification after the move attempt (success or failure)
+        this.eventEmitter.emit("imap.email.received", {
+            userId,
+            emailId,
+            subject: emailData.subject,
+        } as NewImapEmailEvent);
+
+        this.logger.log(
+            `[AutoProcess] Processed uid=${emailData.uid}: ${emailData.subject || "(no subject)"}`,
+        );
+    }
+
+    /**
+     * Opens a short-lived dedicated IMAP connection solely to move a single
+     * message to the ai_analyzed folder (COPY + DELETE).
+     * Using a fresh connection avoids socket timeout after long AI analysis.
+     */
+    private async moveEmailWithFreshConnection(
+        config: ImapConfig,
+        uid: number,
+    ): Promise<void> {
+        const ImapClient = (await import("imapflow")).ImapFlow;
+
+        const client = new ImapClient({
+            host: config.host.trim(),
+            port: config.port,
+            secure: config.security === "ssl",
+            tls:
+                config.security === "starttls"
+                    ? { rejectUnauthorized: false }
+                    : undefined,
+            auth: { user: config.username, pass: config.password },
+            logger: false,
+        });
+        client.on("error", (err: Error) => {
+            this.logger.error(
+                `[ImapFlow] Socket error in moveEmailWithFreshConnection: ${err.message}`,
+            );
+        });
+
+        try {
+            await client.connect();
+            await this.ensureAnalyzedFolderExists(client);
+            await client.mailboxOpen(config.mailbox);
+            await this.moveMessageToAnalyzedFolder(client, uid);
+            await client.logout();
+        } catch (error) {
+            try {
+                await client.logout();
+            } catch {
+                /* ignore */
+            }
+            throw error;
+        }
+    }
+
+    /**
+     * Returns the highest UID currently present in the mailbox, or 0 if empty.
+     * Used to initialise imapLastUid when enabling auto-processing so that
+     * existing emails are not re-processed.
+     */
+    async getMailboxMaxUid(config: ImapConfig): Promise<number> {
+        const ImapClient = (await import("imapflow")).ImapFlow;
+
+        const client = new ImapClient({
+            host: config.host.trim(),
+            port: config.port,
+            secure: config.security === "ssl",
+            tls:
+                config.security === "starttls"
+                    ? { rejectUnauthorized: false }
+                    : undefined,
+            auth: { user: config.username, pass: config.password },
+            logger: false,
+        });
+        client.on("error", (err: Error) => {
+            this.logger.error(
+                `[ImapFlow] Socket error in getMailboxMaxUid: ${err.message}`,
+            );
+        });
+
+        try {
+            await client.connect();
+            const mailboxInfo = await client.mailboxOpen(config.mailbox, {
+                readOnly: true,
+            });
+
+            if (mailboxInfo.exists === 0) {
+                await client.logout();
+                return 0;
+            }
+
+            // Fetch only the last message to get its UID
+            let maxUid = 0;
+            const messages = await client.fetch(
+                "*",
+                { uid: true } as unknown as import("imapflow").FetchQueryObject,
+            );
+            for await (const message of messages) {
+                if (message.uid && message.uid > maxUid) {
+                    maxUid = message.uid;
+                }
+            }
+
+            await client.logout();
+            return maxUid;
+        } catch (error) {
+            this.logger.error(
+                `[getMailboxMaxUid] Failed: ${error instanceof Error ? error.message : String(error)}`,
+            );
+            try {
+                await client.logout();
+            } catch {
+                /* ignore */
+            }
             throw error;
         }
     }

--- a/apps/backend/src/imap/imap-poller.service.ts
+++ b/apps/backend/src/imap/imap-poller.service.ts
@@ -104,7 +104,11 @@ export class ImapPollerService {
 
         for (const emailData of emailsToProcess) {
             try {
-                await this.processDetectedEmail(emailData, config, adminUser.id);
+                await this.processDetectedEmail(
+                    emailData,
+                    config,
+                    adminUser.id,
+                );
             } catch (error) {
                 this.logger.error(
                     `[AutoProcess] Failed for uid=${emailData.uid}: ${error instanceof Error ? error.message : String(error)}`,
@@ -143,23 +147,6 @@ export class ImapPollerService {
                 );
             }
         }
-    }
-
-    /**
-     * Checks if a message is in the AI-Analyzed folder.
-     * Note: For Gmail, checks labels. For other providers (GMX, etc.),
-     * we rely on the database check since we can't easily check folder membership.
-     */
-    private isMessageInAnalyzedFolder(message: {
-        labels?: Set<string>;
-    }): boolean {
-        // For Gmail, check labels
-        if (message.labels) {
-            return message.labels.has(this.ANALYZED_FOLDER);
-        }
-        // For non-Gmail providers (GMX, etc.), labels don't exist
-        // We can't easily check folder membership here, so we rely on DB check
-        return false;
     }
 
     /**
@@ -298,9 +285,7 @@ export class ImapPollerService {
 
                 detected.push({
                     uid: message.uid,
-                    subject: decodeMailHeader(
-                        message.envelope?.subject || "",
-                    ),
+                    subject: decodeMailHeader(message.envelope?.subject || ""),
                     sender: message.envelope?.from?.[0]?.address ?? null,
                     body: decodeQuotedPrintable(
                         this.extractTextContent(message),
@@ -472,10 +457,9 @@ export class ImapPollerService {
 
             // Fetch only the last message to get its UID
             let maxUid = 0;
-            const messages = await client.fetch(
-                "*",
-                { uid: true } as unknown as import("imapflow").FetchQueryObject,
-            );
+            const messages = await client.fetch("*", {
+                uid: true,
+            } as unknown as import("imapflow").FetchQueryObject);
             for await (const message of messages) {
                 if (message.uid && message.uid > maxUid) {
                     maxUid = message.uid;
@@ -518,7 +502,9 @@ export class ImapPollerService {
             logger: false,
         });
         client.on("error", (err: Error) => {
-            this.logger.error(`[ImapFlow] Socket error in getMailboxMessageCount: ${err.message}`);
+            this.logger.error(
+                `[ImapFlow] Socket error in getMailboxMessageCount: ${err.message}`,
+            );
         });
 
         try {
@@ -561,7 +547,9 @@ export class ImapPollerService {
             logger: false,
         });
         client.on("error", (err: Error) => {
-            this.logger.error(`[ImapFlow] Socket error in processExistingEmails: ${err.message}`);
+            this.logger.error(
+                `[ImapFlow] Socket error in processExistingEmails: ${err.message}`,
+            );
         });
 
         try {
@@ -648,7 +636,9 @@ export class ImapPollerService {
             logger: false,
         });
         client.on("error", (err: Error) => {
-            this.logger.error(`[ImapFlow] Socket error in listFolders: ${err.message}`);
+            this.logger.error(
+                `[ImapFlow] Socket error in listFolders: ${err.message}`,
+            );
         });
 
         try {
@@ -696,7 +686,9 @@ export class ImapPollerService {
             logger: false,
         });
         client.on("error", (err: Error) => {
-            this.logger.error(`[ImapFlow] Socket error in getInboxEmails: ${err.message}`);
+            this.logger.error(
+                `[ImapFlow] Socket error in getInboxEmails: ${err.message}`,
+            );
         });
 
         try {
@@ -783,7 +775,9 @@ export class ImapPollerService {
             logger: false,
         });
         client.on("error", (err: Error) => {
-            this.logger.error(`[ImapFlow] Socket error in getEmailBody: ${err.message}`);
+            this.logger.error(
+                `[ImapFlow] Socket error in getEmailBody: ${err.message}`,
+            );
         });
 
         try {
@@ -855,7 +849,9 @@ export class ImapPollerService {
             logger: false,
         });
         client.on("error", (err: Error) => {
-            this.logger.error(`[ImapFlow] Socket error in analyzeSelectedEmails: ${err.message}`);
+            this.logger.error(
+                `[ImapFlow] Socket error in analyzeSelectedEmails: ${err.message}`,
+            );
         });
 
         let processedCount = 0;
@@ -1010,7 +1006,9 @@ export class ImapPollerService {
             this.logger.error(
                 `[analyzeSelected] Fatal: ${error instanceof Error ? error.message : String(error)}`,
             );
-            uids.forEach((uid) => this.processingUids.delete(uid));
+            for (const uid of uids) {
+                this.processingUids.delete(uid);
+            }
             try {
                 await client.logout();
             } catch {

--- a/apps/backend/src/imap/imap-poller.service.ts
+++ b/apps/backend/src/imap/imap-poller.service.ts
@@ -28,6 +28,7 @@ export interface NewImapEmailEvent {
 export class ImapPollerService {
     private readonly logger = new Logger(ImapPollerService.name);
     private isRunning = false;
+    private readonly processingUids = new Set<number>();
     private readonly ANALYZED_FOLDER = "ai_analyzed";
     private analyzedFolderPath: string | null = null;
 
@@ -606,6 +607,10 @@ export class ImapPollerService {
                 ) {
                     continue;
                 }
+                // Hide UIDs that are currently being processed (manual analyze in progress)
+                if (this.processingUids.has(message.uid)) {
+                    continue;
+                }
                 emails.push({
                     uid: message.uid,
                     subject: message.envelope?.subject
@@ -730,6 +735,10 @@ export class ImapPollerService {
         });
 
         let processedCount = 0;
+
+        for (const uid of uids) {
+            this.processingUids.add(uid);
+        }
 
         try {
             await client.connect();
@@ -861,6 +870,8 @@ export class ImapPollerService {
                     this.logger.error(
                         `[analyzeSelected] Failed for uid=${uid}: ${error instanceof Error ? error.message : String(error)}`,
                     );
+                } finally {
+                    this.processingUids.delete(uid);
                 }
             }
 
@@ -875,6 +886,7 @@ export class ImapPollerService {
             this.logger.error(
                 `[analyzeSelected] Fatal: ${error instanceof Error ? error.message : String(error)}`,
             );
+            uids.forEach((uid) => this.processingUids.delete(uid));
             try {
                 await client.logout();
             } catch {

--- a/apps/backend/src/imap/imap.controller.ts
+++ b/apps/backend/src/imap/imap.controller.ts
@@ -2,6 +2,7 @@ import {
     Body,
     Controller,
     Get,
+    HttpCode,
     Logger,
     Param,
     ParseIntPipe,
@@ -71,6 +72,7 @@ export class ImapController {
             password: dto.password,
             security: dto.security,
             mailbox: dto.mailbox,
+            lastUid: 0,
         });
 
         // Update the stored connection status based on test result
@@ -169,10 +171,33 @@ export class ImapController {
             password: dto.password,
             security: dto.security,
             mailbox: dto.mailbox,
+            lastUid: 0,
         });
         this.logger.log(
             `[saveConfig] testConnection result: isConnected=${testResult.isConnected} error=${testResult.lastError ?? "none"}`,
         );
+
+        // When enabling auto-process, snapshot the current max UID so that
+        // existing emails in the inbox are not picked up by the cron job.
+        let initialLastUid: number | undefined;
+        if (dto.autoProcessEnabled && testResult.isConnected) {
+            try {
+                initialLastUid = await this.imapPollerService.getMailboxMaxUid({
+                    host: dto.host,
+                    port: dto.port,
+                    username: dto.username,
+                    password: dto.password,
+                    security: dto.security,
+                    mailbox: dto.mailbox,
+                    lastUid: 0,
+                });
+                this.logger.log(
+                    `[saveConfig] Snapshotted max UID for auto-process: ${initialLastUid}`,
+                );
+            } catch {
+                initialLastUid = 0;
+            }
+        }
 
         await this.settingsService.saveImapConfig(
             {
@@ -184,6 +209,7 @@ export class ImapController {
                 mailbox: dto.mailbox,
                 enabled: dto.enabled && testResult.isConnected,
                 autoProcessEnabled: dto.autoProcessEnabled,
+                initialLastUid,
             },
             testResult.isConnected,
         );
@@ -262,6 +288,7 @@ export class ImapController {
     }
 
     @Post("analyze-selected")
+    @HttpCode(200)
     @Roles([UserRole.ADMIN])
     @ApiCookieAuth("apiKeyCookie")
     @ApiOperation({
@@ -310,6 +337,7 @@ export class ImapController {
             password: dto.password,
             security: dto.security,
             mailbox: dto.mailbox,
+            lastUid: 0,
         });
 
         return { count };
@@ -343,6 +371,7 @@ export class ImapController {
                     password: dto.password,
                     security: dto.security,
                     mailbox: dto.mailbox,
+                    lastUid: 0,
                 },
                 user.id,
             );

--- a/apps/backend/src/imap/imap.controller.ts
+++ b/apps/backend/src/imap/imap.controller.ts
@@ -134,6 +134,7 @@ export class ImapController {
             security: config.security,
             mailbox: config.mailbox,
             enabled: false, // Will be determined by getImapStatus
+            autoProcessEnabled: config.autoProcessEnabled,
         };
     }
 

--- a/apps/backend/src/imap/imap.service.ts
+++ b/apps/backend/src/imap/imap.service.ts
@@ -8,6 +8,7 @@ export interface ImapConfig {
     password: string;
     security: "ssl" | "starttls" | "none";
     mailbox: string;
+    lastUid: number;
 }
 
 export interface ImapStatus {

--- a/apps/backend/src/settings/settings.service.ts
+++ b/apps/backend/src/settings/settings.service.ts
@@ -386,6 +386,7 @@ export class SettingsService {
         mailbox: string;
         autoProcessEnabled: boolean;
         autoProcessEnabledAt: Date | null;
+        lastUid: number;
     } | null> {
         const settings = await this.prismaService.instanceSettings.findUnique({
             where: { id: INSTANCE_SETTINGS_ID },
@@ -398,6 +399,7 @@ export class SettingsService {
                 imapMailbox: true,
                 imapAutoProcessEnabled: true,
                 imapAutoProcessEnabledAt: true,
+                imapLastUid: true,
             },
         });
 
@@ -421,6 +423,7 @@ export class SettingsService {
             mailbox: settings.imapMailbox || "INBOX",
             autoProcessEnabled: settings.imapAutoProcessEnabled,
             autoProcessEnabledAt: settings.imapAutoProcessEnabledAt ?? null,
+            lastUid: settings.imapLastUid ?? 0,
         };
     }
 
@@ -509,6 +512,7 @@ export class SettingsService {
             mailbox: string;
             enabled: boolean;
             autoProcessEnabled: boolean;
+            initialLastUid?: number;
         },
         isConnected?: boolean,
     ): Promise<void> {
@@ -546,6 +550,9 @@ export class SettingsService {
                 imapIsConnected: isConnected ?? false,
                 imapAutoProcessEnabled: config.autoProcessEnabled,
                 imapLastSyncedAt: config.autoProcessEnabled ? now : undefined,
+                imapLastUid: config.autoProcessEnabled
+                    ? (config.initialLastUid ?? 0)
+                    : 0,
                 imapAutoProcessEnabledAt: config.autoProcessEnabled
                     ? now
                     : undefined,
@@ -561,10 +568,14 @@ export class SettingsService {
                 imapIsConnected: isConnected ?? false,
                 imapAutoProcessEnabled: config.autoProcessEnabled,
                 ...(activatingAutoProcess
-                    ? { imapLastSyncedAt: now, imapAutoProcessEnabledAt: now }
+                    ? {
+                          imapLastSyncedAt: now,
+                          imapLastUid: config.initialLastUid ?? 0,
+                          imapAutoProcessEnabledAt: now,
+                      }
                     : {}),
                 ...(deactivatingAutoProcess
-                    ? { imapAutoProcessEnabledAt: null }
+                    ? { imapAutoProcessEnabledAt: null, imapLastUid: 0 }
                     : {}),
             },
         });

--- a/apps/backend/src/settings/settings.service.ts
+++ b/apps/backend/src/settings/settings.service.ts
@@ -524,13 +524,17 @@ export class SettingsService {
         // imapAutoProcessEnabledAt = now() so the cron only picks up emails arriving after this point.
         const existing = await this.prismaService.instanceSettings.findUnique({
             where: { id: INSTANCE_SETTINGS_ID },
-            select: { imapAutoProcessEnabled: true, imapAutoProcessEnabledAt: true },
+            select: {
+                imapAutoProcessEnabled: true,
+                imapAutoProcessEnabledAt: true,
+            },
         });
         const wasAutoProcessEnabled = existing?.imapAutoProcessEnabled ?? false;
         // Activate when: switching on, OR already on but timestamp was never set (migration case)
         const activatingAutoProcess =
             config.autoProcessEnabled &&
-            (!wasAutoProcessEnabled || existing?.imapAutoProcessEnabledAt === null);
+            (!wasAutoProcessEnabled ||
+                existing?.imapAutoProcessEnabledAt === null);
         const deactivatingAutoProcess =
             !config.autoProcessEnabled && wasAutoProcessEnabled;
 

--- a/apps/backend/src/settings/settings.service.ts
+++ b/apps/backend/src/settings/settings.service.ts
@@ -385,6 +385,7 @@ export class SettingsService {
         security: "ssl" | "starttls" | "none";
         mailbox: string;
         autoProcessEnabled: boolean;
+        autoProcessEnabledAt: Date | null;
     } | null> {
         const settings = await this.prismaService.instanceSettings.findUnique({
             where: { id: INSTANCE_SETTINGS_ID },
@@ -396,6 +397,7 @@ export class SettingsService {
                 imapSecurity: true,
                 imapMailbox: true,
                 imapAutoProcessEnabled: true,
+                imapAutoProcessEnabledAt: true,
             },
         });
 
@@ -418,6 +420,7 @@ export class SettingsService {
                 (settings.imapSecurity as "ssl" | "starttls" | "none") || "ssl",
             mailbox: settings.imapMailbox || "INBOX",
             autoProcessEnabled: settings.imapAutoProcessEnabled,
+            autoProcessEnabledAt: settings.imapAutoProcessEnabledAt ?? null,
         };
     }
 
@@ -513,15 +516,21 @@ export class SettingsService {
             ? this.encryptValue(config.password)
             : null;
 
-        // When auto-process is being enabled for the first time, set imapLastSyncedAt = now()
-        // so the cron job only picks up emails arriving after this point.
+        // When auto-process is being enabled for the first time, set imapLastSyncedAt and
+        // imapAutoProcessEnabledAt = now() so the cron only picks up emails arriving after this point.
         const existing = await this.prismaService.instanceSettings.findUnique({
             where: { id: INSTANCE_SETTINGS_ID },
-            select: { imapAutoProcessEnabled: true },
+            select: { imapAutoProcessEnabled: true, imapAutoProcessEnabledAt: true },
         });
         const wasAutoProcessEnabled = existing?.imapAutoProcessEnabled ?? false;
+        // Activate when: switching on, OR already on but timestamp was never set (migration case)
         const activatingAutoProcess =
-            config.autoProcessEnabled && !wasAutoProcessEnabled;
+            config.autoProcessEnabled &&
+            (!wasAutoProcessEnabled || existing?.imapAutoProcessEnabledAt === null);
+        const deactivatingAutoProcess =
+            !config.autoProcessEnabled && wasAutoProcessEnabled;
+
+        const now = new Date();
 
         await this.prismaService.instanceSettings.upsert({
             where: { id: INSTANCE_SETTINGS_ID },
@@ -536,8 +545,9 @@ export class SettingsService {
                 imapEnabled: config.enabled,
                 imapIsConnected: isConnected ?? false,
                 imapAutoProcessEnabled: config.autoProcessEnabled,
-                imapLastSyncedAt: config.autoProcessEnabled
-                    ? new Date()
+                imapLastSyncedAt: config.autoProcessEnabled ? now : undefined,
+                imapAutoProcessEnabledAt: config.autoProcessEnabled
+                    ? now
                     : undefined,
             },
             update: {
@@ -551,7 +561,10 @@ export class SettingsService {
                 imapIsConnected: isConnected ?? false,
                 imapAutoProcessEnabled: config.autoProcessEnabled,
                 ...(activatingAutoProcess
-                    ? { imapLastSyncedAt: new Date() }
+                    ? { imapLastSyncedAt: now, imapAutoProcessEnabledAt: now }
+                    : {}),
+                ...(deactivatingAutoProcess
+                    ? { imapAutoProcessEnabledAt: null }
                     : {}),
             },
         });

--- a/apps/backend/tsconfig.json
+++ b/apps/backend/tsconfig.json
@@ -16,7 +16,7 @@
         "baseUrl": "./",
         "incremental": true,
         "skipLibCheck": true,
-        "ignoreDeprecations": "6.0",
+        "ignoreDeprecations": "5.0",
         "strictNullChecks": true,
         "forceConsistentCasingInFileNames": true,
         "noImplicitAny": true,

--- a/apps/backend/tsconfig.json
+++ b/apps/backend/tsconfig.json
@@ -16,7 +16,7 @@
         "baseUrl": "./",
         "incremental": true,
         "skipLibCheck": true,
-        "ignoreDeprecations": "5.0",
+        "ignoreDeprecations": "6.0",
         "strictNullChecks": true,
         "forceConsistentCasingInFileNames": true,
         "noImplicitAny": true,

--- a/apps/frontend/app/(dashboard)/layout.tsx
+++ b/apps/frontend/app/(dashboard)/layout.tsx
@@ -5,10 +5,9 @@ import type React from "react";
 import { useEffect } from "react";
 import { Sidebar } from "@/components/composites/sidebar/sidebar";
 import { DashboardLoadingView } from "@/components/composites/views/dashboard-loading-view";
-import { useNotifications } from "@/lib/use-notifications";
-
 import useLogout from "@/hooks/useLogout";
 import { authClient } from "@/lib/auth-client";
+import { useNotifications } from "@/lib/use-notifications";
 
 export default function DashboardLayout({
     children,

--- a/apps/frontend/app/(dashboard)/layout.tsx
+++ b/apps/frontend/app/(dashboard)/layout.tsx
@@ -5,6 +5,7 @@ import type React from "react";
 import { useEffect } from "react";
 import { Sidebar } from "@/components/composites/sidebar/sidebar";
 import { DashboardLoadingView } from "@/components/composites/views/dashboard-loading-view";
+import { useNotifications } from "@/lib/use-notifications";
 
 import useLogout from "@/hooks/useLogout";
 import { authClient } from "@/lib/auth-client";
@@ -14,6 +15,7 @@ export default function DashboardLayout({
 }: {
     children: React.ReactNode;
 }) {
+    useNotifications();
     const { data: session, isPending } = authClient.useSession();
     const router = useRouter();
     const { logout } = useLogout();

--- a/apps/frontend/src/components/composites/views/imap/imap-view.tsx
+++ b/apps/frontend/src/components/composites/views/imap/imap-view.tsx
@@ -8,6 +8,7 @@ import { SplitViewPane } from "@/components/composites/views/split-view/split-vi
 import { StyledButton } from "@/components/ui/styled-button";
 import { StyledSkeleton } from "@/components/ui/styled-skeleton";
 import {
+    type imapControllerGetInboxEmailsResponseSuccess,
     getImapControllerGetEmailBodyQueryKey,
     getImapControllerGetInboxEmailsQueryKey,
     useImapControllerAnalyzeSelected,
@@ -44,6 +45,31 @@ export function ImapView() {
 
     const analyzeSelected = useImapControllerAnalyzeSelected({
         mutation: {
+            onMutate: async ({ data: { uids } }) => {
+                await queryClient.cancelQueries({
+                    queryKey: getImapControllerGetInboxEmailsQueryKey(),
+                });
+                const previousData =
+                    queryClient.getQueryData<imapControllerGetInboxEmailsResponseSuccess>(
+                        getImapControllerGetInboxEmailsQueryKey(),
+                    );
+                queryClient.setQueryData<imapControllerGetInboxEmailsResponseSuccess>(
+                    getImapControllerGetInboxEmailsQueryKey(),
+                    (old) => {
+                        if (!old?.data?.emails) return old;
+                        return {
+                            ...old,
+                            data: {
+                                ...old.data,
+                                emails: old.data.emails.filter(
+                                    (email) => !uids.includes(email.uid),
+                                ),
+                            },
+                        };
+                    },
+                );
+                return { previousData };
+            },
             onSuccess: (response) => {
                 if (response.status === 200) {
                     const count = response.data.processedCount;
@@ -54,19 +80,27 @@ export function ImapView() {
                     setSelectedUids(new Set());
                     setPreviewUid(null);
                     queryClient.invalidateQueries({
-                        queryKey: getImapControllerGetInboxEmailsQueryKey(),
-                    });
-                    queryClient.invalidateQueries({
                         queryKey: getJobControllerGetHistoryQueryKey({
                             source: "IMAP",
                         }),
                     });
                 }
             },
-            onError: () => {
+            onError: (_error, _variables, context) => {
+                if (context?.previousData !== undefined) {
+                    queryClient.setQueryData(
+                        getImapControllerGetInboxEmailsQueryKey(),
+                        context.previousData,
+                    );
+                }
                 showPersistentErrorToast({
                     title: "Analysis failed",
                     description: "Could not process the selected emails.",
+                });
+            },
+            onSettled: () => {
+                queryClient.invalidateQueries({
+                    queryKey: getImapControllerGetInboxEmailsQueryKey(),
                 });
             },
         },

--- a/apps/frontend/src/components/composites/views/imap/imap-view.tsx
+++ b/apps/frontend/src/components/composites/views/imap/imap-view.tsx
@@ -8,9 +8,9 @@ import { SplitViewPane } from "@/components/composites/views/split-view/split-vi
 import { StyledButton } from "@/components/ui/styled-button";
 import { StyledSkeleton } from "@/components/ui/styled-skeleton";
 import {
-    type imapControllerGetInboxEmailsResponseSuccess,
     getImapControllerGetEmailBodyQueryKey,
     getImapControllerGetInboxEmailsQueryKey,
+    type imapControllerGetInboxEmailsResponseSuccess,
     useImapControllerAnalyzeSelected,
     useImapControllerGetEmailBody,
     useImapControllerGetInboxEmails,

--- a/apps/frontend/src/components/composites/views/imap/imap-view.tsx
+++ b/apps/frontend/src/components/composites/views/imap/imap-view.tsx
@@ -84,6 +84,9 @@ export function ImapView() {
                             source: "IMAP",
                         }),
                     });
+                    queryClient.invalidateQueries({
+                        queryKey: getJobControllerGetHistoryQueryKey({}),
+                    });
                 }
             },
             onError: (_error, _variables, context) => {

--- a/apps/frontend/src/components/composites/views/settings/sections/mail-section.tsx
+++ b/apps/frontend/src/components/composites/views/settings/sections/mail-section.tsx
@@ -98,9 +98,7 @@ export function MailSection() {
                 username: config.username || "",
                 password: "", // Password is not returned for security
                 security: config.security || "ssl",
-                autoProcessEnabled:
-                    (config as { autoProcessEnabled?: boolean })
-                        .autoProcessEnabled ?? false,
+                autoProcessEnabled: config.autoProcessEnabled ?? false,
             });
             if (config.mailbox) {
                 setSelectedMailbox(config.mailbox);

--- a/apps/frontend/src/lib/use-notifications.ts
+++ b/apps/frontend/src/lib/use-notifications.ts
@@ -1,11 +1,17 @@
 "use client";
 
+import { useQueryClient } from "@tanstack/react-query";
 import { useEffect, useRef } from "react";
 import { io, type Socket } from "socket.io-client";
+import {
+    getImapControllerGetInboxEmailsQueryKey,
+} from "@/lib/client/imap/imap";
+import { getJobControllerGetHistoryQueryKey } from "@/lib/client/jobs/jobs";
 import { showSuccessToast } from "@/lib/toast";
 
 export function useNotifications() {
     const socketRef = useRef<Socket | null>(null);
+    const queryClient = useQueryClient();
 
     useEffect(() => {
         // Connect to WebSocket server
@@ -34,6 +40,17 @@ export function useNotifications() {
                         title: "New Email Received",
                         description: `A new email "${data.data.subject || "(no subject)"}" has been processed from IMAP.`,
                     });
+                    queryClient.invalidateQueries({
+                        queryKey: getImapControllerGetInboxEmailsQueryKey(),
+                    });
+                    queryClient.invalidateQueries({
+                        queryKey: getJobControllerGetHistoryQueryKey({
+                            source: "IMAP",
+                        }),
+                    });
+                    queryClient.invalidateQueries({
+                        queryKey: getJobControllerGetHistoryQueryKey({}),
+                    });
                 }
             },
         );
@@ -41,7 +58,7 @@ export function useNotifications() {
         return () => {
             socket.disconnect();
         };
-    }, []);
+    }, [queryClient]);
 
     return socketRef.current;
 }

--- a/apps/frontend/src/lib/use-notifications.ts
+++ b/apps/frontend/src/lib/use-notifications.ts
@@ -9,7 +9,7 @@ export function useNotifications() {
 
     useEffect(() => {
         // Connect to WebSocket server
-        const socket = io("http://localhost:5175/notifications", {
+        const socket = io(`${process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:5175"}/notifications`, {
             withCredentials: true,
         });
 

--- a/apps/frontend/src/lib/use-notifications.ts
+++ b/apps/frontend/src/lib/use-notifications.ts
@@ -3,9 +3,7 @@
 import { useQueryClient } from "@tanstack/react-query";
 import { useEffect, useRef } from "react";
 import { io, type Socket } from "socket.io-client";
-import {
-    getImapControllerGetInboxEmailsQueryKey,
-} from "@/lib/client/imap/imap";
+import { getImapControllerGetInboxEmailsQueryKey } from "@/lib/client/imap/imap";
 import { getJobControllerGetHistoryQueryKey } from "@/lib/client/jobs/jobs";
 import { showSuccessToast } from "@/lib/toast";
 
@@ -15,9 +13,12 @@ export function useNotifications() {
 
     useEffect(() => {
         // Connect to WebSocket server
-        const socket = io(`${process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:5175"}/notifications`, {
-            withCredentials: true,
-        });
+        const socket = io(
+            `${process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:5175"}/notifications`,
+            {
+                withCredentials: true,
+            },
+        );
 
         socketRef.current = socket;
 

--- a/wiki/Architecture.md
+++ b/wiki/Architecture.md
@@ -20,7 +20,8 @@ Core backend entities:
 - `Email`
 - `Job`
 - `JobResult`
-- `InstanceSettings` — singleton row holding IMAP connection config, `imapLastUid` (UID watermark for auto-polling), `imapAutoProcessEnabledAt`, and the encrypted IMAP password.
+- `InstanceSettings` — singleton row holding IMAP connection config, `imapLastUid` (UID watermark for auto-polling),
+  `imapAutoProcessEnabledAt`, and the encrypted IMAP password.
 - `ProviderSettings`
 
 Auth entities (`Session`, `Account`, `Verification`) are also persisted.
@@ -77,13 +78,16 @@ IMAP ingestion is handled end-to-end by backend orchestration with frontend admi
    - `imapLastUid` tracks the highest message UID seen so far; new messages are detected by fetching UIDs above this value.
    - `imapAutoProcessEnabledAt` records the timestamp when auto-processing was last activated.
 3. Frontend `IMAP` view lists current inbox emails and allows selecting messages for analysis (`POST /api/imap/analyze-selected`).
-   - Emails that arrived after `imapAutoProcessEnabledAt` are hidden from the inbox list when auto-process is active (they will be handled by the cron job).
+   - Emails that arrived after `imapAutoProcessEnabledAt` are hidden from the inbox list when auto-process is active
+     (they will be handled by the cron job).
    - Emails currently being analyzed (either via manual selection or auto-process) are hidden from the inbox list in real time to prevent duplicate submissions.
 4. Backend IMAP processing writes results into the same `Email`/`Job`/`JobResult` pipeline with `Email.source = IMAP`.
 5. Processed messages are moved to `ai_analyzed` via COPY + DELETE to avoid repeated analysis.
 6. When auto-process is enabled, backend polls the IMAP mailbox every 30 seconds using a two-phase approach:
-   - **Detection phase** — a short-lived IMAP connection fetches all messages with UID > `imapLastUid`. `imapLastUid` is advanced immediately and the connection is closed before AI analysis starts.
-   - **Processing phase** — each detected email is analyzed by the AI-backend; a separate short-lived IMAP connection is opened per message to move it to `ai_analyzed`. This avoids socket-timeout issues caused by long-running AI calls.
+   - **Detection phase** — a short-lived IMAP connection fetches all messages with UID > `imapLastUid`.
+     `imapLastUid` is advanced immediately and the connection is closed before AI analysis starts.
+   - **Processing phase** — each detected email is analyzed by the AI-backend; a separate short-lived IMAP connection
+     is opened per message to move it to `ai_analyzed`. This avoids socket-timeout issues from long AI calls.
 7. Backend emits notification events over the `notifications` WebSocket namespace for newly processed IMAP emails.
 
 ## AI-backend flow architecture

--- a/wiki/Architecture.md
+++ b/wiki/Architecture.md
@@ -20,7 +20,7 @@ Core backend entities:
 - `Email`
 - `Job`
 - `JobResult`
-- `InstanceSettings`
+- `InstanceSettings` — singleton row holding IMAP connection config, `imapLastUid` (UID watermark for auto-polling), `imapAutoProcessEnabledAt`, and the encrypted IMAP password.
 - `ProviderSettings`
 
 Auth entities (`Session`, `Account`, `Verification`) are also persisted.
@@ -74,11 +74,17 @@ IMAP ingestion is handled end-to-end by backend orchestration with frontend admi
 
 1. Admin configures mailbox connection in `Settings -> Mail` (`host`, `port`, credentials, security, inbox folder, auto-process toggle).
 2. Backend stores IMAP settings in `InstanceSettings` and encrypts the IMAP password at rest.
+   - `imapLastUid` tracks the highest message UID seen so far; new messages are detected by fetching UIDs above this value.
+   - `imapAutoProcessEnabledAt` records the timestamp when auto-processing was last activated.
 3. Frontend `IMAP` view lists current inbox emails and allows selecting messages for analysis (`POST /api/imap/analyze-selected`).
+   - Emails that arrived after `imapAutoProcessEnabledAt` are hidden from the inbox list when auto-process is active (they will be handled by the cron job).
+   - Emails currently being analyzed (either via manual selection or auto-process) are hidden from the inbox list in real time to prevent duplicate submissions.
 4. Backend IMAP processing writes results into the same `Email`/`Job`/`JobResult` pipeline with `Email.source = IMAP`.
-5. Processed messages are moved to `ai_analyzed` to avoid repeated analysis.
-6. When auto-process is enabled, backend polls IMAP every minute and processes newly arriving emails.
-7. Backend also emits notification events over the `notifications` WebSocket namespace for newly processed IMAP emails.
+5. Processed messages are moved to `ai_analyzed` via COPY + DELETE to avoid repeated analysis.
+6. When auto-process is enabled, backend polls the IMAP mailbox every 30 seconds using a two-phase approach:
+   - **Detection phase** — a short-lived IMAP connection fetches all messages with UID > `imapLastUid`. `imapLastUid` is advanced immediately and the connection is closed before AI analysis starts.
+   - **Processing phase** — each detected email is analyzed by the AI-backend; a separate short-lived IMAP connection is opened per message to move it to `ai_analyzed`. This avoids socket-timeout issues caused by long-running AI calls.
+7. Backend emits notification events over the `notifications` WebSocket namespace for newly processed IMAP emails.
 
 ## AI-backend flow architecture
 


### PR DESCRIPTION
## Summary

- **IMAP analyze toast was silently suppressed**: \`@Post\` in NestJS defaults to HTTP 201, but the frontend checked \`response.status === 200\` — condition always false, so neither the success toast nor query invalidation ever fired
- **History \"All\" tab not updating**: after manual IMAP analyze and after auto-process notifications, only the \`source: \"IMAP\"\` query key was invalidated; the \"All\" key was missing
- **Unreliable auto-detection**: IMAP's \`SINCE\` criterion is day-granular (no time component), causing every cron tick to re-scan all messages from today and relying on slow DB duplicate checks; race conditions could also double-process emails when AI analysis took >30 s

## Changes

### Backend
- \`@HttpCode(200)\` added to \`analyzeSelected\` endpoint to match the OpenAPI spec and make the frontend status check work
- \`imapLastUid Int @default(0)\` added to \`InstanceSettings\` schema (migrated via \`prisma db push\`)
- When auto-process is enabled, the current mailbox max UID is snapshotted so pre-existing emails are never auto-processed
- \`detectNewEmails\` now fetches \`UID (lastUid+1):*\` — exact, monotonic, no date ambiguity
- \`imapLastUid\` is advanced immediately after detection (before AI processing) to prevent back-to-back cron ticks from re-detecting the same messages
- \`processingUids\` guard added inside \`detectNewEmails\` to prevent double-processing by concurrent cron ticks

### Frontend
- \`onSuccess\` in IMAP view now also invalidates \`getJobControllerGetHistoryQueryKey({})\` (the \"All\" tab)
- \`use-notifications.ts\` auto-process notification handler does the same

## Test plan

- [ ] Enable IMAP auto-process with emails already in inbox → pre-existing emails are **not** auto-processed
- [ ] Send a new email → appears in history under both \"IMAP\" and \"All\" within one cron interval (≤30 s)
- [ ] Manually analyze from IMAP view → success toast appears, email shows in \"All\" history immediately
- [ ] Send two emails in quick succession → both are processed exactly once (no duplicates)
- [ ] Disable and re-enable auto-process → \`imapLastUid\` resets, new snapshot taken