### PR TITLE
feat(#319): add auto-send confidence threshold for IMAP responses

### DIFF
--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -136,6 +136,7 @@ model InstanceSettings {
     imapLastUid             Int       @default(0)
     imapAutoProcessEnabled   Boolean   @default(false)
     imapAutoProcessEnabledAt DateTime?
+    imapAutoSendThreshold    Int?
     createdAt        DateTime  @default(now())
     updatedAt        DateTime  @updatedAt
 

--- a/apps/backend/src/imap/dto/imap-config.dto.ts
+++ b/apps/backend/src/imap/dto/imap-config.dto.ts
@@ -43,4 +43,14 @@ export class ImapConfigDto {
         example: false,
     })
     autoProcessEnabled!: boolean;
+
+    @ApiProperty({
+        description:
+            "Confidence score threshold (0–100) above which IMAP responses are sent automatically. Null disables auto-send.",
+        type: Number,
+        example: 80,
+        nullable: true,
+        required: false,
+    })
+    autoSendThreshold!: number | null;
 }

--- a/apps/backend/src/imap/dto/save-imap-config.dto.ts
+++ b/apps/backend/src/imap/dto/save-imap-config.dto.ts
@@ -49,4 +49,14 @@ export class SaveImapConfigDto {
         example: false,
     })
     autoProcessEnabled!: boolean;
+
+    @ApiProperty({
+        description:
+            "Confidence score threshold (0–100) above which IMAP responses are sent automatically. Null disables auto-send.",
+        type: Number,
+        example: 80,
+        nullable: true,
+        required: false,
+    })
+    autoSendThreshold!: number | null;
 }

--- a/apps/backend/src/imap/imap-poller.service.ts
+++ b/apps/backend/src/imap/imap-poller.service.ts
@@ -11,6 +11,7 @@ import { AiBackendService } from "../ai-backend/ai-backend.service";
 import { decodeMailHeader, decodeQuotedPrintable } from "../lib/mail-encoding";
 import { PrismaService } from "../prisma/prisma.service";
 import { SettingsService } from "../settings/settings.service";
+import { SmtpService } from "../smtp/smtp.service";
 import type {
     InboxEmailBodyDto,
     InboxEmailDto,
@@ -46,6 +47,7 @@ export class ImapPollerService {
         readonly _imapService: ImapService,
         private readonly eventEmitter: EventEmitter2,
         private readonly aiBackendService: AiBackendService,
+        private readonly smtpService: SmtpService,
     ) {}
 
     /**
@@ -323,6 +325,7 @@ export class ImapPollerService {
         const now = new Date();
 
         let emailId = "";
+        let jobId = "";
         await this.prismaService.$transaction(async (tx) => {
             const email = await tx.email.create({
                 data: {
@@ -344,6 +347,7 @@ export class ImapPollerService {
                     completedAt: now,
                 },
             });
+            jobId = job.id;
 
             await tx.jobResult.create({
                 data: {
@@ -361,6 +365,38 @@ export class ImapPollerService {
             this.logger.warn(
                 `[AutoProcess] Could not move uid=${emailData.uid}: ${moveError instanceof Error ? moveError.message : String(moveError)}`,
             );
+        }
+
+        // Auto-send response if confidence score meets the configured threshold
+        const threshold = config.autoSendThreshold;
+        const score = analysisResult.confidence_assessment?.score;
+        const emailResponse = analysisResult.email_response;
+        if (
+            threshold !== null &&
+            score !== null &&
+            score !== undefined &&
+            score >= threshold &&
+            emailResponse &&
+            emailData.sender
+        ) {
+            try {
+                await this.smtpService.sendMail(
+                    emailData.sender,
+                    emailResponse.response_subject,
+                    emailResponse.response_body,
+                );
+                await this.prismaService.job.update({
+                    where: { id: jobId },
+                    data: { handled: true },
+                });
+                this.logger.log(
+                    `[AutoSend] Sent response for uid=${emailData.uid} (score=${score} >= threshold=${threshold})`,
+                );
+            } catch (sendError) {
+                this.logger.error(
+                    `[AutoSend] Failed to send response for uid=${emailData.uid}: ${sendError instanceof Error ? sendError.message : String(sendError)}`,
+                );
+            }
         }
 
         // Emit notification after the move attempt (success or failure)

--- a/apps/backend/src/imap/imap.controller.ts
+++ b/apps/backend/src/imap/imap.controller.ts
@@ -73,6 +73,7 @@ export class ImapController {
             security: dto.security,
             mailbox: dto.mailbox,
             lastUid: 0,
+            autoSendThreshold: null,
         });
 
         // Update the stored connection status based on test result
@@ -137,6 +138,7 @@ export class ImapController {
             mailbox: config.mailbox,
             enabled: false, // Will be determined by getImapStatus
             autoProcessEnabled: config.autoProcessEnabled,
+            autoSendThreshold: config.autoSendThreshold,
         };
     }
 
@@ -172,6 +174,7 @@ export class ImapController {
             security: dto.security,
             mailbox: dto.mailbox,
             lastUid: 0,
+            autoSendThreshold: null,
         });
         this.logger.log(
             `[saveConfig] testConnection result: isConnected=${testResult.isConnected} error=${testResult.lastError ?? "none"}`,
@@ -190,6 +193,7 @@ export class ImapController {
                     security: dto.security,
                     mailbox: dto.mailbox,
                     lastUid: 0,
+                    autoSendThreshold: null,
                 });
                 this.logger.log(
                     `[saveConfig] Snapshotted max UID for auto-process: ${initialLastUid}`,
@@ -209,6 +213,7 @@ export class ImapController {
                 mailbox: dto.mailbox,
                 enabled: dto.enabled && testResult.isConnected,
                 autoProcessEnabled: dto.autoProcessEnabled,
+                autoSendThreshold: dto.autoSendThreshold ?? null,
                 initialLastUid,
             },
             testResult.isConnected,
@@ -338,6 +343,7 @@ export class ImapController {
             security: dto.security,
             mailbox: dto.mailbox,
             lastUid: 0,
+            autoSendThreshold: null,
         });
 
         return { count };
@@ -372,6 +378,7 @@ export class ImapController {
                     security: dto.security,
                     mailbox: dto.mailbox,
                     lastUid: 0,
+                    autoSendThreshold: null,
                 },
                 user.id,
             );

--- a/apps/backend/src/imap/imap.module.ts
+++ b/apps/backend/src/imap/imap.module.ts
@@ -4,6 +4,7 @@ import { ScheduleModule } from "@nestjs/schedule";
 import { AiBackendModule } from "../ai-backend/ai-backend.module";
 import { PrismaModule } from "../prisma/prisma.module";
 import { SettingsModule } from "../settings/settings.module";
+import { SmtpModule } from "../smtp/smtp.module";
 import { ImapController } from "./imap.controller";
 import { ImapService } from "./imap.service";
 import { ImapPollerService } from "./imap-poller.service";
@@ -13,6 +14,7 @@ import { ImapPollerService } from "./imap-poller.service";
         SettingsModule,
         PrismaModule,
         AiBackendModule,
+        SmtpModule,
         ScheduleModule.forRoot(),
         EventEmitterModule.forRoot(),
     ],

--- a/apps/backend/src/imap/imap.service.ts
+++ b/apps/backend/src/imap/imap.service.ts
@@ -9,6 +9,7 @@ export interface ImapConfig {
     security: "ssl" | "starttls" | "none";
     mailbox: string;
     lastUid: number;
+    autoSendThreshold: number | null;
 }
 
 export interface ImapStatus {

--- a/apps/backend/src/settings/settings.service.ts
+++ b/apps/backend/src/settings/settings.service.ts
@@ -387,6 +387,7 @@ export class SettingsService {
         autoProcessEnabled: boolean;
         autoProcessEnabledAt: Date | null;
         lastUid: number;
+        autoSendThreshold: number | null;
     } | null> {
         const settings = await this.prismaService.instanceSettings.findUnique({
             where: { id: INSTANCE_SETTINGS_ID },
@@ -400,6 +401,7 @@ export class SettingsService {
                 imapAutoProcessEnabled: true,
                 imapAutoProcessEnabledAt: true,
                 imapLastUid: true,
+                imapAutoSendThreshold: true,
             },
         });
 
@@ -424,6 +426,7 @@ export class SettingsService {
             autoProcessEnabled: settings.imapAutoProcessEnabled,
             autoProcessEnabledAt: settings.imapAutoProcessEnabledAt ?? null,
             lastUid: settings.imapLastUid ?? 0,
+            autoSendThreshold: settings.imapAutoSendThreshold ?? null,
         };
     }
 
@@ -512,6 +515,7 @@ export class SettingsService {
             mailbox: string;
             enabled: boolean;
             autoProcessEnabled: boolean;
+            autoSendThreshold: number | null;
             initialLastUid?: number;
         },
         isConnected?: boolean,
@@ -560,6 +564,7 @@ export class SettingsService {
                 imapAutoProcessEnabledAt: config.autoProcessEnabled
                     ? now
                     : undefined,
+                imapAutoSendThreshold: config.autoSendThreshold,
             },
             update: {
                 imapHost: config.host,
@@ -571,6 +576,7 @@ export class SettingsService {
                 imapEnabled: config.enabled,
                 imapIsConnected: isConnected ?? false,
                 imapAutoProcessEnabled: config.autoProcessEnabled,
+                imapAutoSendThreshold: config.autoSendThreshold,
                 ...(activatingAutoProcess
                     ? {
                           imapLastSyncedAt: now,

--- a/apps/frontend/src/components/composites/views/settings/sections/mail-section.tsx
+++ b/apps/frontend/src/components/composites/views/settings/sections/mail-section.tsx
@@ -51,6 +51,7 @@ const formSchema = z.object({
     password: z.string().min(1, "Password is required."),
     security: z.enum(["ssl", "starttls", "none"]),
     autoProcessEnabled: z.boolean(),
+    autoSendThreshold: z.number().int().min(0).max(100).nullable(),
 });
 
 type FormValues = z.infer<typeof formSchema>;
@@ -85,6 +86,7 @@ export function MailSection() {
             password: "",
             security: "ssl",
             autoProcessEnabled: false,
+            autoSendThreshold: null,
         },
     });
 
@@ -99,6 +101,7 @@ export function MailSection() {
                 password: "", // Password is not returned for security
                 security: config.security || "ssl",
                 autoProcessEnabled: config.autoProcessEnabled ?? false,
+                autoSendThreshold: config.autoSendThreshold ?? null,
             });
             if (config.mailbox) {
                 setSelectedMailbox(config.mailbox);
@@ -217,6 +220,7 @@ export function MailSection() {
                     mailbox: folder,
                     enabled: true,
                     autoProcessEnabled: pendingFormValues.autoProcessEnabled,
+                    autoSendThreshold: pendingFormValues.autoSendThreshold ?? null,
                 },
             });
 
@@ -489,6 +493,52 @@ export function MailSection() {
                                     </p>
                                 </div>
                             </label>
+                        )}
+                    />
+                </div>
+
+                {/* Auto-send confidence threshold */}
+                <div className="rounded-xl border border-slate-200 bg-slate-50 p-4 dark:border-slate-800 dark:bg-slate-900/50">
+                    <Controller
+                        name="autoSendThreshold"
+                        control={form.control}
+                        render={({ field, fieldState }) => (
+                            <div className="flex flex-col gap-3">
+                                <div>
+                                    <p className="text-sm font-medium text-slate-900 dark:text-white">
+                                        Auto-send confidence threshold
+                                    </p>
+                                    <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+                                        IMAP responses with a confidence score
+                                        at or above this value (0–100) are sent
+                                        automatically via SMTP. Leave empty to
+                                        disable.
+                                    </p>
+                                </div>
+                                <div className="space-y-1">
+                                    <StyledInput
+                                        type="number"
+                                        inputMode="numeric"
+                                        min={0}
+                                        max={100}
+                                        placeholder="e.g. 80 (leave empty to disable)"
+                                        value={field.value ?? ""}
+                                        onChange={(e) =>
+                                            field.onChange(
+                                                e.target.value === ""
+                                                    ? null
+                                                    : Number(e.target.value),
+                                            )
+                                        }
+                                        disabled={isLoading}
+                                    />
+                                    {fieldState.error && (
+                                        <p className="text-xs text-red-500">
+                                            {fieldState.error.message}
+                                        </p>
+                                    )}
+                                </div>
+                            </div>
                         )}
                     />
                 </div>

--- a/apps/frontend/src/components/composites/views/settings/sections/mail-section.tsx
+++ b/apps/frontend/src/components/composites/views/settings/sections/mail-section.tsx
@@ -220,7 +220,8 @@ export function MailSection() {
                     mailbox: folder,
                     enabled: true,
                     autoProcessEnabled: pendingFormValues.autoProcessEnabled,
-                    autoSendThreshold: pendingFormValues.autoSendThreshold ?? null,
+                    autoSendThreshold:
+                        pendingFormValues.autoSendThreshold ?? null,
                 },
             });
 

--- a/wiki/Architecture.md
+++ b/wiki/Architecture.md
@@ -21,7 +21,8 @@ Core backend entities:
 - `Job`
 - `JobResult`
 - `InstanceSettings` — singleton row holding IMAP connection config, `imapLastUid` (UID watermark for auto-polling),
-  `imapAutoProcessEnabledAt`, and the encrypted IMAP password.
+  `imapAutoProcessEnabledAt`, `imapAutoSendThreshold` (nullable 0–100 confidence threshold for auto-sending responses),
+  and the encrypted IMAP password.
 - `ProviderSettings`
 
 Auth entities (`Session`, `Account`, `Verification`) are also persisted.
@@ -52,7 +53,9 @@ Every `Job` carries a `handled` boolean (`false` by default). It tracks whether 
 
 **How a job becomes handled:**
 
-- **Automatic** — when a user sends the generated email response via the `Send Email Response` button
+- **Automatic (IMAP auto-send)** — when `imapAutoSendThreshold` is set and the AI confidence score meets or
+  exceeds the threshold, the IMAP poller sends the response via SMTP and marks the job as handled immediately.
+- **Automatic (manual send)** — when a user sends the generated email response via the `Send Email Response` button
   (in either the `Analyze` or `History` view), the backend marks the corresponding job as handled
   immediately after the SMTP send succeeds.
 - **Manual** — any user can toggle the handled state directly from the history list with the `Mark handled` / `Unmark` button on each card.
@@ -73,10 +76,14 @@ Every `Job` carries a `handled` boolean (`false` by default). It tracks whether 
 
 IMAP ingestion is handled end-to-end by backend orchestration with frontend admin controls:
 
-1. Admin configures mailbox connection in `Settings -> Mail` (`host`, `port`, credentials, security, inbox folder, auto-process toggle).
+1. Admin configures mailbox connection in `Settings -> Mail` (`host`, `port`, credentials, security, inbox folder,
+   auto-process toggle, and optional auto-send confidence threshold).
 2. Backend stores IMAP settings in `InstanceSettings` and encrypts the IMAP password at rest.
    - `imapLastUid` tracks the highest message UID seen so far; new messages are detected by fetching UIDs above this value.
    - `imapAutoProcessEnabledAt` records the timestamp when auto-processing was last activated.
+   - `imapAutoSendThreshold` (nullable `Int`, 0–100) — when set, the poller automatically sends the AI-generated
+     response via SMTP and marks the job `handled = true` if `confidence_assessment.score >= threshold`.
+     Leave `null` to disable auto-send (responses must be sent manually from the History view).
 3. Frontend `IMAP` view lists current inbox emails and allows selecting messages for analysis (`POST /api/imap/analyze-selected`).
    - Emails that arrived after `imapAutoProcessEnabledAt` are hidden from the inbox list when auto-process is active
      (they will be handled by the cron job).
@@ -88,7 +95,11 @@ IMAP ingestion is handled end-to-end by backend orchestration with frontend admi
      `imapLastUid` is advanced immediately and the connection is closed before AI analysis starts.
    - **Processing phase** — each detected email is analyzed by the AI-backend; a separate short-lived IMAP connection
      is opened per message to move it to `ai_analyzed`. This avoids socket-timeout issues from long AI calls.
-7. Backend emits notification events over the `notifications` WebSocket namespace for newly processed IMAP emails.
+7. If `imapAutoSendThreshold` is configured, the poller checks the AI confidence score after each analysis:
+   - Score ≥ threshold → response is sent via SMTP, job marked `handled = true`. Errors are logged but do not
+     abort the overall processing pipeline.
+   - Score < threshold or threshold is `null` → no auto-send; response remains available for manual send in History.
+8. Backend emits notification events over the `notifications` WebSocket namespace for newly processed IMAP emails.
 
 ## AI-backend flow architecture
 

--- a/wiki/Configuration.md
+++ b/wiki/Configuration.md
@@ -77,9 +77,17 @@ Optional seed-data settings:
 ## IMAP configuration note
 
 IMAP connection settings (`host`, `port`, `username`, `password`, `security`, `mailbox`,
-auto-process toggle) are configured in the app via `Settings -> Mail` and stored in backend
-`InstanceSettings` (password encrypted with `SETTINGS_ENCRYPTION_KEY`), not in environment
-variables.
+auto-process toggle, and auto-send confidence threshold) are configured in the app via
+`Settings -> Mail` and stored in backend `InstanceSettings` (password encrypted with
+`SETTINGS_ENCRYPTION_KEY`), not in environment variables.
+
+The **auto-send confidence threshold** (`imapAutoSendThreshold`, 0–100) is distinct from the
+env-var `AUTO_SEND_RESPOND_THRESHOLD`:
+
+| Setting | Scope | Configured via |
+|---------|-------|---------------|
+| `AUTO_SEND_RESPOND_THRESHOLD` | Manual email submissions (`POST /api/emails`) | Environment variable |
+| `imapAutoSendThreshold` | IMAP auto-processed emails | `Settings -> Mail` UI |
 
 ## Frontend (`apps/frontend`) variables
 


### PR DESCRIPTION
## Summary

- Adds `imapAutoSendThreshold` (nullable `Int`, 0–100) to `InstanceSettings` — configurable via `Settings -> Mail`
- IMAP poller automatically sends the AI-generated response via SMTP and marks the job `handled = true` when `confidence_assessment.score >= threshold`
- Threshold `null` disables auto-send (existing behaviour unchanged)
- `AUTO_SEND_RESPOND_THRESHOLD` env-var logic for manual submissions (`POST /api/emails`) is left untouched

## Changes

- **Prisma schema**: `imapAutoSendThreshold Int?` on `InstanceSettings`
- **Backend**: `ImapConfig` interface, `SettingsService`, DTOs, controller, and `ImapPollerService` updated; `SmtpModule` injected into `ImapModule`
- **Frontend**: Zod schema + number input added to `mail-section.tsx`
- **Wiki**: `Architecture.md` and `Configuration.md` updated to document the new setting and distinguish it from the env-var threshold

## Test plan

- [ ] `GET /api/imap/config` returns `autoSendThreshold: null` for existing installs
- [ ] `PUT /api/imap/config` with `autoSendThreshold: 80` → subsequent GET returns `80`
- [ ] Frontend threshold input saves and loads correctly; empty field → `null`
- [ ] IMAP poller with score ≥ threshold: SMTP send triggered, `job.handled = true`
- [ ] Score < threshold: no SMTP send, `job.handled = false`
- [ ] Threshold `null`: no auto-send regardless of score
- [ ] Manual submit (`POST /api/emails`) behaviour unchanged

Closes #319