### PR TITLE
fix(#323): remove duplicate mail response in history view

### DIFF
--- a/apps/frontend/src/components/composites/views/history/history-analysis-panel.tsx
+++ b/apps/frontend/src/components/composites/views/history/history-analysis-panel.tsx
@@ -61,9 +61,6 @@ export function HistoryAnalysisPanel({
                     <div className="space-y-6">
                         <CategorySection result={renderableResult} />
                         <SummarySection result={renderableResult} />
-                        <HistoryEmailResponseSection
-                            result={renderableResult}
-                        />
                         <ConfidenceSection result={renderableResult} />
                     </div>
                 </StyledTabsContent>
@@ -98,25 +95,6 @@ export function HistoryAnalysisPanel({
                 </ResultSection>
             </StyledTabsContent>
         </StyledTabs>
-    );
-}
-
-function HistoryEmailResponseSection({ result }: { result: AnalysisResult }) {
-    const responseBody = result.email_response?.response_body;
-    if (typeof responseBody !== "string" || responseBody.length === 0) {
-        return null;
-    }
-
-    return (
-        <ResultSection title="Email Response">
-            <ResultCard className="text-sm leading-relaxed text-slate-700 whitespace-break-spaces dark:text-slate-300">
-                <CopyActionButton
-                    title="Copy Email body"
-                    copyText={responseBody}
-                />
-                {responseBody}
-            </ResultCard>
-        </ResultSection>
     );
 }
 


### PR DESCRIPTION
## Summary

Closes #323

In the history view, the mail response was rendered twice:
1. As a read-only block inside `HistoryAnalysisPanel` (no button)
2. As the full `EmailResponseSection` below (with send/confirm button)

Both components pulled from the same `result.email_response` data.

## Changes

- Removed `HistoryEmailResponseSection` sub-component from `history-analysis-panel.tsx`
- The actionable `EmailResponseSection` (with send/confirm button) remains as the single source of truth